### PR TITLE
Update Zero permissions to match schema

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -50,7 +50,7 @@ type AuthData = {
 
 export const permissions = definePermissions<AuthData, Schema>(schema, () => {
 	return {
-		issue: {
+		todo: {
 			row: {
 				delete: ANYONE_CAN,
 				insert: ANYONE_CAN


### PR DESCRIPTION
The permissions declaration wasn't passing typechecks because it referenced a table `issue` that doesn't exist in the zero schema.