### PR TITLE
Fixed typo in lib/index.ts

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,3 +1,3 @@
 // Reexport your entry components here
 export * from './Z.svelte';
-export * from './Query.svelte';
+export * from './query.svelte';


### PR DESCRIPTION
In the index file was Query.svelte but the file imported from is query.svelte.ts. This led to a build issue when importing from this index file.