### PR TITLE
Add zero-provider and zero-init components

### DIFF
--- a/src/lib/components/zero-init.svelte
+++ b/src/lib/components/zero-init.svelte
@@ -1,0 +1,26 @@
+<script module lang="ts">
+	// Export a typed version of useZero that knows about your specific schema
+	// If using custom mutators, pass them in as the second type argument, such as <Schema, ReturnType<typeof createMutators>>
+	export const useZero = () => useZeroGeneric<Schema>();
+	import ZeroProvider, { useZero as useZeroGeneric } from '$lib/zero-provider.svelte';
+</script>
+
+<script lang="ts">
+	import { PUBLIC_SERVER } from '$env/static/public';
+	import { type ZeroOptions } from '@rocicorp/zero';
+	import { schema, type Schema } from '../../schema.js';
+
+	let { children } = $props();
+
+	// If using custom mutators, pass them in as the second type argument, such as: ZeroOptions<Schema, ReturnType<typeof createMutators>>
+	const zeroOpts: ZeroOptions<Schema> = {
+		server: PUBLIC_SERVER,
+		schema,
+		userID: 'anon',
+		kvStore: 'mem'
+	};
+</script>
+
+<ZeroProvider {...zeroOpts}>
+	{@render children?.()}
+</ZeroProvider>

--- a/src/lib/zero-provider.svelte
+++ b/src/lib/zero-provider.svelte
@@ -34,19 +34,22 @@
 	// more likely server support will be opt-in with a new prop on this
 	// component.
 
-	$effect.pre(() => {
-		if ('zero' in props) {
-			const zero = props.zero as Z<S, MD>;
-			setContext(ZERO_CONTEXT_KEY, zero);
-			return;
-		}
+	let z: Z<S, MD>;
 
-		const z = new Z(props);
+	if ('zero' in props) {
+		z = props.zero as Z<S, MD>;
+	} else {
+		z = new Z(props);
 		init?.(z);
-		setContext(ZERO_CONTEXT_KEY, z);
+	}
 
+	setContext(ZERO_CONTEXT_KEY, z);
+
+	// Cleanup the Zero instance when this component is destroyed.
+	$effect(() => {
 		return () => {
-			void z.close();
+			z.close();
+			setContext(ZERO_CONTEXT_KEY, undefined);
 		};
 	});
 </script>

--- a/src/lib/zero-provider.svelte
+++ b/src/lib/zero-provider.svelte
@@ -1,0 +1,54 @@
+<script module lang="ts">
+	import type { CustomMutatorDefs, Schema, ZeroOptions } from '@rocicorp/zero';
+	import { getContext, setContext } from 'svelte';
+	import { Z } from './Z.svelte.js';
+
+	const ZERO_CONTEXT_KEY = Symbol.for('zero-provider');
+
+	export function useZero<
+		S extends Schema,
+		MD extends CustomMutatorDefs<S> | undefined = undefined
+	>(): Z<S, MD> {
+		const zero = getContext(ZERO_CONTEXT_KEY);
+		if (zero === undefined) {
+			throw new Error('useZero must be used within a ZeroProvider');
+		}
+		return zero as Z<S, MD>;
+	}
+</script>
+
+<script
+	lang="ts"
+	generics="S extends Schema, MD extends CustomMutatorDefs<S> | undefined = undefined"
+>
+	type Props = (ZeroOptions<S, MD> | { zero: Z<S, MD> }) & {
+		init?: (zero: Z<S, MD>) => void;
+		children?: import('svelte').Snippet;
+	};
+
+	let { init = () => {}, children, ...props }: Props = $props();
+
+	// If Zero is not passed in, we construct it, but only client-side.
+	// Zero doesn't really work SSR today so this is usually the right thing.
+	// When we support Zero SSR this will either become a breaking change or
+	// more likely server support will be opt-in with a new prop on this
+	// component.
+
+	$effect.pre(() => {
+		if ('zero' in props) {
+			const zero = props.zero as Z<S, MD>;
+			setContext(ZERO_CONTEXT_KEY, zero);
+			return;
+		}
+
+		const z = new Z(props);
+		init?.(z);
+		setContext(ZERO_CONTEXT_KEY, z);
+
+		return () => {
+			void z.close();
+		};
+	});
+</script>
+
+{@render children?.()}

--- a/src/lib/zero-provider.svelte
+++ b/src/lib/zero-provider.svelte
@@ -28,7 +28,7 @@
 
 	let { init = () => {}, children, ...props }: Props = $props();
 
-	// If Zero is not passed in, we construct it, but only client-side.
+	// If Zero is not passed in, we construct it. (SSR must be disabled, for now.)
 	// Zero doesn't really work SSR today so this is usually the right thing.
 	// When we support Zero SSR this will either become a breaking change or
 	// more likely server support will be opt-in with a new prop on this

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+	import ZeroInit from '$lib/components/zero-init.svelte';
+
+	let { children } = $props();
+</script>
+
+<ZeroInit>
+	{@render children?.()}
+</ZeroInit>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,15 +1,9 @@
 <script lang="ts">
-	import './styles.css';
-	import { PUBLIC_SERVER } from '$env/static/public';
+	import { useZero } from '$lib/components/zero-init.svelte';
 	import { Query } from '$lib/query.svelte.js';
-	import { Z } from '$lib/Z.svelte.js';
-	import { schema, type Schema } from '../schema.js';
-	const z = new Z<Schema>({
-		server: PUBLIC_SERVER,
-		schema,
-		userID: 'anon',
-		kvStore: 'mem'
-	});
+	import './styles.css';
+
+	const z = useZero();
 
 	let filtered_type: string | undefined = $state();
 
@@ -20,7 +14,7 @@
 		}
 		return new Query(z.current.query.todo.related('type'));
 	});
-$inspect(todos.current)
+	$inspect(todos.current);
 	// Basic query
 	const types = new Query(z.current.query.type);
 


### PR DESCRIPTION
I attempted to add an implementation of `ZeroProvider,` which is essentially a wrapper component you can put around you layout and manage the same context for Zero.

It stores the Zero instance in Context among other things.

I am not sure if my implementation is is correct or not, feel free to modify.

One issue I ran into was I could not infer the correct types from `useZero` from the Provider component itself, so I had to create a wrapper for it in the `zero-init` component. Maybe there is a better way I am missing?

Here is the React version:
https://github.com/rocicorp/mono/blob/831038b2d938672634cdbbe7f92b2c7342245ffe/packages/zero-react/src/zero-provider.tsx

ZeroProvider can be used together with a component such as `ZeroInit` which I also included an example of. This is not included in the Zero library itself but utilizes `ZeroProvider` to setup the Zero instance.

The react comparison is here:
https://github.com/rocicorp/mono/blob/831038b2d938672634cdbbe7f92b2c7342245ffe/apps/zbugs/src/zero-init.tsx#L4