### PR TITLE
Update zero to 23 and support Synced Queries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
 	"name": "zero-svelte",
-	"version": "0.3.4",
+	"version": "0.3.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "zero-svelte",
-			"version": "0.3.4",
+			"version": "0.3.5",
 			"dependencies": {
-				"@rocicorp/zero": "^0.22.2025080200"
+				"@rocicorp/zero": "^0.23.0"
 			},
 			"devDependencies": {
 				"@sveltejs/adapter-auto": "^6.0.1",
@@ -27,7 +27,8 @@
 				"svelte-check": "^4.2.1",
 				"typescript": "^5.8.3",
 				"typescript-eslint": "^8.33.1",
-				"vite": "^6.3.3"
+				"vite": "^6.3.3",
+				"zod": "^4.1.5"
 			},
 			"peerDependencies": {
 				"svelte": "^5.15.0"
@@ -848,9 +849,9 @@
 			}
 		},
 		"node_modules/@grpc/grpc-js": {
-			"version": "1.13.3",
-			"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.13.3.tgz",
-			"integrity": "sha512-FTXHdOoPbZrBjlVLHuKbDZnsTxXv2BlHF57xw6LuThXacXvtkahEPED0CKMk6obZDf65Hv4k3z62eyPNpvinIg==",
+			"version": "1.13.4",
+			"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.13.4.tgz",
+			"integrity": "sha512-GsFaMXCkMqkKIvwCQjCrwH+GHbPKBjhwo/8ZuUkWHqbI73Kky9I+pQltrlT0+MWpedCoosda53lgjYfyEPgxBg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@grpc/proto-loader": "^0.7.13",
@@ -1091,9 +1092,9 @@
 			}
 		},
 		"node_modules/@opentelemetry/api-logs": {
-			"version": "0.200.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.200.0.tgz",
-			"integrity": "sha512-IKJBQxh91qJ+3ssRly5hYEJ8NDHu9oY/B1PXVSCWf7zytmYO9RNLB0Ox9XQ/fJ8m6gY6Q6NtBWlmXfaXt5Uc4Q==",
+			"version": "0.203.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.203.0.tgz",
+			"integrity": "sha512-9B9RU0H7Ya1Dx/Rkyc4stuBZSGVQF27WigitInx2QQoj6KUpEFYPKoWjdFTunJYxmXmh17HeBvbMa1EhGyPmqQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/api": "^1.3.0"
@@ -1103,59 +1104,59 @@
 			}
 		},
 		"node_modules/@opentelemetry/auto-instrumentations-node": {
-			"version": "0.58.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.58.1.tgz",
-			"integrity": "sha512-hAsNw5XtFTytQ6GrCspIwKKSamXQGfAvRfqOL93VTqaI1WFBhndyXsNrjAzqULvK0JwMJOuZb77ckdrvJrW3vA==",
+			"version": "0.62.2",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.62.2.tgz",
+			"integrity": "sha512-Ipe6X7ddrCiRsuewyTU83IvKiSFT4piqmv9z8Ovg1E7v98pdTj1pUE6sDrHV50zl7/ypd+cONBgt+EYSZu4u9Q==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/instrumentation": "^0.200.0",
-				"@opentelemetry/instrumentation-amqplib": "^0.47.0",
-				"@opentelemetry/instrumentation-aws-lambda": "^0.51.1",
-				"@opentelemetry/instrumentation-aws-sdk": "^0.52.0",
-				"@opentelemetry/instrumentation-bunyan": "^0.46.0",
-				"@opentelemetry/instrumentation-cassandra-driver": "^0.46.0",
-				"@opentelemetry/instrumentation-connect": "^0.44.0",
-				"@opentelemetry/instrumentation-cucumber": "^0.15.0",
-				"@opentelemetry/instrumentation-dataloader": "^0.17.0",
-				"@opentelemetry/instrumentation-dns": "^0.44.0",
-				"@opentelemetry/instrumentation-express": "^0.49.0",
-				"@opentelemetry/instrumentation-fastify": "^0.45.0",
-				"@opentelemetry/instrumentation-fs": "^0.20.0",
-				"@opentelemetry/instrumentation-generic-pool": "^0.44.0",
-				"@opentelemetry/instrumentation-graphql": "^0.48.0",
-				"@opentelemetry/instrumentation-grpc": "^0.200.0",
-				"@opentelemetry/instrumentation-hapi": "^0.46.0",
-				"@opentelemetry/instrumentation-http": "^0.200.0",
-				"@opentelemetry/instrumentation-ioredis": "^0.48.0",
-				"@opentelemetry/instrumentation-kafkajs": "^0.9.2",
-				"@opentelemetry/instrumentation-knex": "^0.45.0",
-				"@opentelemetry/instrumentation-koa": "^0.48.0",
-				"@opentelemetry/instrumentation-lru-memoizer": "^0.45.0",
-				"@opentelemetry/instrumentation-memcached": "^0.44.0",
-				"@opentelemetry/instrumentation-mongodb": "^0.53.0",
-				"@opentelemetry/instrumentation-mongoose": "^0.47.1",
-				"@opentelemetry/instrumentation-mysql": "^0.46.0",
-				"@opentelemetry/instrumentation-mysql2": "^0.46.0",
-				"@opentelemetry/instrumentation-nestjs-core": "^0.46.0",
-				"@opentelemetry/instrumentation-net": "^0.44.0",
-				"@opentelemetry/instrumentation-pg": "^0.52.0",
-				"@opentelemetry/instrumentation-pino": "^0.47.0",
-				"@opentelemetry/instrumentation-redis": "^0.47.0",
-				"@opentelemetry/instrumentation-redis-4": "^0.47.0",
-				"@opentelemetry/instrumentation-restify": "^0.46.0",
-				"@opentelemetry/instrumentation-router": "^0.45.0",
-				"@opentelemetry/instrumentation-runtime-node": "^0.14.0",
-				"@opentelemetry/instrumentation-socket.io": "^0.47.0",
-				"@opentelemetry/instrumentation-tedious": "^0.19.0",
-				"@opentelemetry/instrumentation-undici": "^0.11.0",
-				"@opentelemetry/instrumentation-winston": "^0.45.0",
-				"@opentelemetry/resource-detector-alibaba-cloud": "^0.31.0",
-				"@opentelemetry/resource-detector-aws": "^2.0.0",
-				"@opentelemetry/resource-detector-azure": "^0.7.0",
-				"@opentelemetry/resource-detector-container": "^0.7.0",
-				"@opentelemetry/resource-detector-gcp": "^0.34.0",
+				"@opentelemetry/instrumentation": "^0.203.0",
+				"@opentelemetry/instrumentation-amqplib": "^0.50.0",
+				"@opentelemetry/instrumentation-aws-lambda": "^0.54.1",
+				"@opentelemetry/instrumentation-aws-sdk": "^0.58.0",
+				"@opentelemetry/instrumentation-bunyan": "^0.49.0",
+				"@opentelemetry/instrumentation-cassandra-driver": "^0.49.0",
+				"@opentelemetry/instrumentation-connect": "^0.47.0",
+				"@opentelemetry/instrumentation-cucumber": "^0.19.0",
+				"@opentelemetry/instrumentation-dataloader": "^0.21.1",
+				"@opentelemetry/instrumentation-dns": "^0.47.0",
+				"@opentelemetry/instrumentation-express": "^0.52.0",
+				"@opentelemetry/instrumentation-fastify": "^0.48.0",
+				"@opentelemetry/instrumentation-fs": "^0.23.0",
+				"@opentelemetry/instrumentation-generic-pool": "^0.47.0",
+				"@opentelemetry/instrumentation-graphql": "^0.51.0",
+				"@opentelemetry/instrumentation-grpc": "^0.203.0",
+				"@opentelemetry/instrumentation-hapi": "^0.50.0",
+				"@opentelemetry/instrumentation-http": "^0.203.0",
+				"@opentelemetry/instrumentation-ioredis": "^0.51.0",
+				"@opentelemetry/instrumentation-kafkajs": "^0.13.0",
+				"@opentelemetry/instrumentation-knex": "^0.48.0",
+				"@opentelemetry/instrumentation-koa": "^0.51.0",
+				"@opentelemetry/instrumentation-lru-memoizer": "^0.48.0",
+				"@opentelemetry/instrumentation-memcached": "^0.47.0",
+				"@opentelemetry/instrumentation-mongodb": "^0.56.0",
+				"@opentelemetry/instrumentation-mongoose": "^0.50.0",
+				"@opentelemetry/instrumentation-mysql": "^0.49.0",
+				"@opentelemetry/instrumentation-mysql2": "^0.50.0",
+				"@opentelemetry/instrumentation-nestjs-core": "^0.49.0",
+				"@opentelemetry/instrumentation-net": "^0.47.0",
+				"@opentelemetry/instrumentation-oracledb": "^0.29.0",
+				"@opentelemetry/instrumentation-pg": "^0.56.1",
+				"@opentelemetry/instrumentation-pino": "^0.50.1",
+				"@opentelemetry/instrumentation-redis": "^0.52.0",
+				"@opentelemetry/instrumentation-restify": "^0.49.0",
+				"@opentelemetry/instrumentation-router": "^0.48.0",
+				"@opentelemetry/instrumentation-runtime-node": "^0.17.1",
+				"@opentelemetry/instrumentation-socket.io": "^0.50.0",
+				"@opentelemetry/instrumentation-tedious": "^0.22.0",
+				"@opentelemetry/instrumentation-undici": "^0.14.0",
+				"@opentelemetry/instrumentation-winston": "^0.48.1",
+				"@opentelemetry/resource-detector-alibaba-cloud": "^0.31.3",
+				"@opentelemetry/resource-detector-aws": "^2.3.0",
+				"@opentelemetry/resource-detector-azure": "^0.10.0",
+				"@opentelemetry/resource-detector-container": "^0.7.3",
+				"@opentelemetry/resource-detector-gcp": "^0.37.0",
 				"@opentelemetry/resources": "^2.0.0",
-				"@opentelemetry/sdk-node": "^0.200.0"
+				"@opentelemetry/sdk-node": "^0.203.0"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
@@ -1193,505 +1194,194 @@
 			}
 		},
 		"node_modules/@opentelemetry/exporter-logs-otlp-grpc": {
-			"version": "0.200.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.200.0.tgz",
-			"integrity": "sha512-+3MDfa5YQPGM3WXxW9kqGD85Q7s9wlEMVNhXXG7tYFLnIeaseUt9YtCeFhEDFzfEktacdFpOtXmJuNW8cHbU5A==",
+			"version": "0.203.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.203.0.tgz",
+			"integrity": "sha512-g/2Y2noc/l96zmM+g0LdeuyYKINyBwN6FJySoU15LHPLcMN/1a0wNk2SegwKcxrRdE7Xsm7fkIR5n6XFe3QpPw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@grpc/grpc-js": "^1.7.1",
-				"@opentelemetry/core": "2.0.0",
-				"@opentelemetry/otlp-exporter-base": "0.200.0",
-				"@opentelemetry/otlp-grpc-exporter-base": "0.200.0",
-				"@opentelemetry/otlp-transformer": "0.200.0",
-				"@opentelemetry/sdk-logs": "0.200.0"
+				"@opentelemetry/core": "2.0.1",
+				"@opentelemetry/otlp-exporter-base": "0.203.0",
+				"@opentelemetry/otlp-grpc-exporter-base": "0.203.0",
+				"@opentelemetry/otlp-transformer": "0.203.0",
+				"@opentelemetry/sdk-logs": "0.203.0"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.3.0"
-			}
-		},
-		"node_modules/@opentelemetry/exporter-logs-otlp-grpc/node_modules/@opentelemetry/core": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-			"integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
 			}
 		},
 		"node_modules/@opentelemetry/exporter-logs-otlp-http": {
-			"version": "0.200.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.200.0.tgz",
-			"integrity": "sha512-KfWw49htbGGp9s8N4KI8EQ9XuqKJ0VG+yVYVYFiCYSjEV32qpQ5qZ9UZBzOZ6xRb+E16SXOSCT3RkqBVSABZ+g==",
+			"version": "0.203.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.203.0.tgz",
+			"integrity": "sha512-s0hys1ljqlMTbXx2XiplmMJg9wG570Z5lH7wMvrZX6lcODI56sG4HL03jklF63tBeyNwK2RV1/ntXGo3HgG4Qw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/api-logs": "0.200.0",
-				"@opentelemetry/core": "2.0.0",
-				"@opentelemetry/otlp-exporter-base": "0.200.0",
-				"@opentelemetry/otlp-transformer": "0.200.0",
-				"@opentelemetry/sdk-logs": "0.200.0"
+				"@opentelemetry/api-logs": "0.203.0",
+				"@opentelemetry/core": "2.0.1",
+				"@opentelemetry/otlp-exporter-base": "0.203.0",
+				"@opentelemetry/otlp-transformer": "0.203.0",
+				"@opentelemetry/sdk-logs": "0.203.0"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.3.0"
-			}
-		},
-		"node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/core": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-			"integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
 			}
 		},
 		"node_modules/@opentelemetry/exporter-logs-otlp-proto": {
-			"version": "0.200.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.200.0.tgz",
-			"integrity": "sha512-GmahpUU/55hxfH4TP77ChOfftADsCq/nuri73I/AVLe2s4NIglvTsaACkFVZAVmnXXyPS00Fk3x27WS3yO07zA==",
+			"version": "0.203.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.203.0.tgz",
+			"integrity": "sha512-nl/7S91MXn5R1aIzoWtMKGvqxgJgepB/sH9qW0rZvZtabnsjbf8OQ1uSx3yogtvLr0GzwD596nQKz2fV7q2RBw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/api-logs": "0.200.0",
-				"@opentelemetry/core": "2.0.0",
-				"@opentelemetry/otlp-exporter-base": "0.200.0",
-				"@opentelemetry/otlp-transformer": "0.200.0",
-				"@opentelemetry/resources": "2.0.0",
-				"@opentelemetry/sdk-logs": "0.200.0",
-				"@opentelemetry/sdk-trace-base": "2.0.0"
+				"@opentelemetry/api-logs": "0.203.0",
+				"@opentelemetry/core": "2.0.1",
+				"@opentelemetry/otlp-exporter-base": "0.203.0",
+				"@opentelemetry/otlp-transformer": "0.203.0",
+				"@opentelemetry/resources": "2.0.1",
+				"@opentelemetry/sdk-logs": "0.203.0",
+				"@opentelemetry/sdk-trace-base": "2.0.1"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.3.0"
-			}
-		},
-		"node_modules/@opentelemetry/exporter-logs-otlp-proto/node_modules/@opentelemetry/core": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-			"integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/exporter-logs-otlp-proto/node_modules/@opentelemetry/resources": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
-			"integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.0.0",
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.3.0 <1.10.0"
 			}
 		},
 		"node_modules/@opentelemetry/exporter-metrics-otlp-grpc": {
-			"version": "0.200.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.200.0.tgz",
-			"integrity": "sha512-uHawPRvKIrhqH09GloTuYeq2BjyieYHIpiklOvxm9zhrCL2eRsnI/6g9v2BZTVtGp8tEgIa7rCQ6Ltxw6NBgew==",
+			"version": "0.203.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.203.0.tgz",
+			"integrity": "sha512-FCCj9nVZpumPQSEI57jRAA89hQQgONuoC35Lt+rayWY/mzCAc6BQT7RFyFaZKJ2B7IQ8kYjOCPsF/HGFWjdQkQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@grpc/grpc-js": "^1.7.1",
-				"@opentelemetry/core": "2.0.0",
-				"@opentelemetry/exporter-metrics-otlp-http": "0.200.0",
-				"@opentelemetry/otlp-exporter-base": "0.200.0",
-				"@opentelemetry/otlp-grpc-exporter-base": "0.200.0",
-				"@opentelemetry/otlp-transformer": "0.200.0",
-				"@opentelemetry/resources": "2.0.0",
-				"@opentelemetry/sdk-metrics": "2.0.0"
+				"@opentelemetry/core": "2.0.1",
+				"@opentelemetry/exporter-metrics-otlp-http": "0.203.0",
+				"@opentelemetry/otlp-exporter-base": "0.203.0",
+				"@opentelemetry/otlp-grpc-exporter-base": "0.203.0",
+				"@opentelemetry/otlp-transformer": "0.203.0",
+				"@opentelemetry/resources": "2.0.1",
+				"@opentelemetry/sdk-metrics": "2.0.1"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.3.0"
-			}
-		},
-		"node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/core": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-			"integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/resources": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
-			"integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.0.0",
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.3.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/sdk-metrics": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.0.0.tgz",
-			"integrity": "sha512-Bvy8QDjO05umd0+j+gDeWcTaVa1/R2lDj/eOvjzpm8VQj1K1vVZJuyjThpV5/lSHyYW2JaHF2IQ7Z8twJFAhjA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.0.0",
-				"@opentelemetry/resources": "2.0.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.9.0 <1.10.0"
 			}
 		},
 		"node_modules/@opentelemetry/exporter-metrics-otlp-http": {
-			"version": "0.200.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.200.0.tgz",
-			"integrity": "sha512-5BiR6i8yHc9+qW7F6LqkuUnIzVNA7lt0qRxIKcKT+gq3eGUPHZ3DY29sfxI3tkvnwMgtnHDMNze5DdxW39HsAw==",
+			"version": "0.203.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.203.0.tgz",
+			"integrity": "sha512-HFSW10y8lY6BTZecGNpV3GpoSy7eaO0Z6GATwZasnT4bEsILp8UJXNG5OmEsz4SdwCSYvyCbTJdNbZP3/8LGCQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "2.0.0",
-				"@opentelemetry/otlp-exporter-base": "0.200.0",
-				"@opentelemetry/otlp-transformer": "0.200.0",
-				"@opentelemetry/resources": "2.0.0",
-				"@opentelemetry/sdk-metrics": "2.0.0"
+				"@opentelemetry/core": "2.0.1",
+				"@opentelemetry/otlp-exporter-base": "0.203.0",
+				"@opentelemetry/otlp-transformer": "0.203.0",
+				"@opentelemetry/resources": "2.0.1",
+				"@opentelemetry/sdk-metrics": "2.0.1"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.3.0"
-			}
-		},
-		"node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/core": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-			"integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/resources": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
-			"integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.0.0",
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.3.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/sdk-metrics": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.0.0.tgz",
-			"integrity": "sha512-Bvy8QDjO05umd0+j+gDeWcTaVa1/R2lDj/eOvjzpm8VQj1K1vVZJuyjThpV5/lSHyYW2JaHF2IQ7Z8twJFAhjA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.0.0",
-				"@opentelemetry/resources": "2.0.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.9.0 <1.10.0"
 			}
 		},
 		"node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
-			"version": "0.200.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.200.0.tgz",
-			"integrity": "sha512-E+uPj0yyvz81U9pvLZp3oHtFrEzNSqKGVkIViTQY1rH3TOobeJPSpLnTVXACnCwkPR5XeTvPnK3pZ2Kni8AFMg==",
+			"version": "0.203.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.203.0.tgz",
+			"integrity": "sha512-OZnhyd9npU7QbyuHXFEPVm3LnjZYifuKpT3kTnF84mXeEQ84pJJZgyLBpU4FSkSwUkt/zbMyNAI7y5+jYTWGIg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "2.0.0",
-				"@opentelemetry/exporter-metrics-otlp-http": "0.200.0",
-				"@opentelemetry/otlp-exporter-base": "0.200.0",
-				"@opentelemetry/otlp-transformer": "0.200.0",
-				"@opentelemetry/resources": "2.0.0",
-				"@opentelemetry/sdk-metrics": "2.0.0"
+				"@opentelemetry/core": "2.0.1",
+				"@opentelemetry/exporter-metrics-otlp-http": "0.203.0",
+				"@opentelemetry/otlp-exporter-base": "0.203.0",
+				"@opentelemetry/otlp-transformer": "0.203.0",
+				"@opentelemetry/resources": "2.0.1",
+				"@opentelemetry/sdk-metrics": "2.0.1"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.3.0"
-			}
-		},
-		"node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/core": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-			"integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/resources": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
-			"integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.0.0",
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.3.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/sdk-metrics": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.0.0.tgz",
-			"integrity": "sha512-Bvy8QDjO05umd0+j+gDeWcTaVa1/R2lDj/eOvjzpm8VQj1K1vVZJuyjThpV5/lSHyYW2JaHF2IQ7Z8twJFAhjA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.0.0",
-				"@opentelemetry/resources": "2.0.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.9.0 <1.10.0"
 			}
 		},
 		"node_modules/@opentelemetry/exporter-prometheus": {
-			"version": "0.200.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.200.0.tgz",
-			"integrity": "sha512-ZYdlU9r0USuuYppiDyU2VFRA0kFl855ylnb3N/2aOlXrbA4PMCznen7gmPbetGQu7pz8Jbaf4fwvrDnVdQQXSw==",
+			"version": "0.203.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.203.0.tgz",
+			"integrity": "sha512-2jLuNuw5m4sUj/SncDf/mFPabUxMZmmYetx5RKIMIQyPnl6G6ooFzfeE8aXNRf8YD1ZXNlCnRPcISxjveGJHNg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "2.0.0",
-				"@opentelemetry/resources": "2.0.0",
-				"@opentelemetry/sdk-metrics": "2.0.0"
+				"@opentelemetry/core": "2.0.1",
+				"@opentelemetry/resources": "2.0.1",
+				"@opentelemetry/sdk-metrics": "2.0.1"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.3.0"
-			}
-		},
-		"node_modules/@opentelemetry/exporter-prometheus/node_modules/@opentelemetry/core": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-			"integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/exporter-prometheus/node_modules/@opentelemetry/resources": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
-			"integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.0.0",
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.3.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/exporter-prometheus/node_modules/@opentelemetry/sdk-metrics": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.0.0.tgz",
-			"integrity": "sha512-Bvy8QDjO05umd0+j+gDeWcTaVa1/R2lDj/eOvjzpm8VQj1K1vVZJuyjThpV5/lSHyYW2JaHF2IQ7Z8twJFAhjA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.0.0",
-				"@opentelemetry/resources": "2.0.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.9.0 <1.10.0"
 			}
 		},
 		"node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
-			"version": "0.200.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.200.0.tgz",
-			"integrity": "sha512-hmeZrUkFl1YMsgukSuHCFPYeF9df0hHoKeHUthRKFCxiURs+GwF1VuabuHmBMZnjTbsuvNjOB+JSs37Csem/5Q==",
+			"version": "0.203.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.203.0.tgz",
+			"integrity": "sha512-322coOTf81bm6cAA8+ML6A+m4r2xTCdmAZzGNTboPXRzhwPt4JEmovsFAs+grpdarObd68msOJ9FfH3jxM6wqA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@grpc/grpc-js": "^1.7.1",
-				"@opentelemetry/core": "2.0.0",
-				"@opentelemetry/otlp-exporter-base": "0.200.0",
-				"@opentelemetry/otlp-grpc-exporter-base": "0.200.0",
-				"@opentelemetry/otlp-transformer": "0.200.0",
-				"@opentelemetry/resources": "2.0.0",
-				"@opentelemetry/sdk-trace-base": "2.0.0"
+				"@opentelemetry/core": "2.0.1",
+				"@opentelemetry/otlp-exporter-base": "0.203.0",
+				"@opentelemetry/otlp-grpc-exporter-base": "0.203.0",
+				"@opentelemetry/otlp-transformer": "0.203.0",
+				"@opentelemetry/resources": "2.0.1",
+				"@opentelemetry/sdk-trace-base": "2.0.1"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.3.0"
-			}
-		},
-		"node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/core": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-			"integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/resources": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
-			"integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.0.0",
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.3.0 <1.10.0"
 			}
 		},
 		"node_modules/@opentelemetry/exporter-trace-otlp-http": {
-			"version": "0.200.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.200.0.tgz",
-			"integrity": "sha512-Goi//m/7ZHeUedxTGVmEzH19NgqJY+Bzr6zXo1Rni1+hwqaksEyJ44gdlEMREu6dzX1DlAaH/qSykSVzdrdafA==",
+			"version": "0.203.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.203.0.tgz",
+			"integrity": "sha512-ZDiaswNYo0yq/cy1bBLJFe691izEJ6IgNmkjm4C6kE9ub/OMQqDXORx2D2j8fzTBTxONyzusbaZlqtfmyqURPw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "2.0.0",
-				"@opentelemetry/otlp-exporter-base": "0.200.0",
-				"@opentelemetry/otlp-transformer": "0.200.0",
-				"@opentelemetry/resources": "2.0.0",
-				"@opentelemetry/sdk-trace-base": "2.0.0"
+				"@opentelemetry/core": "2.0.1",
+				"@opentelemetry/otlp-exporter-base": "0.203.0",
+				"@opentelemetry/otlp-transformer": "0.203.0",
+				"@opentelemetry/resources": "2.0.1",
+				"@opentelemetry/sdk-trace-base": "2.0.1"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.3.0"
-			}
-		},
-		"node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/core": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-			"integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/resources": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
-			"integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.0.0",
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.3.0 <1.10.0"
 			}
 		},
 		"node_modules/@opentelemetry/exporter-trace-otlp-proto": {
-			"version": "0.200.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.200.0.tgz",
-			"integrity": "sha512-V9TDSD3PjK1OREw2iT9TUTzNYEVWJk4Nhodzhp9eiz4onDMYmPy3LaGbPv81yIR6dUb/hNp/SIhpiCHwFUq2Vg==",
+			"version": "0.203.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.203.0.tgz",
+			"integrity": "sha512-1xwNTJ86L0aJmWRwENCJlH4LULMG2sOXWIVw+Szta4fkqKVY50Eo4HoVKKq6U9QEytrWCr8+zjw0q/ZOeXpcAQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "2.0.0",
-				"@opentelemetry/otlp-exporter-base": "0.200.0",
-				"@opentelemetry/otlp-transformer": "0.200.0",
-				"@opentelemetry/resources": "2.0.0",
-				"@opentelemetry/sdk-trace-base": "2.0.0"
+				"@opentelemetry/core": "2.0.1",
+				"@opentelemetry/otlp-exporter-base": "0.203.0",
+				"@opentelemetry/otlp-transformer": "0.203.0",
+				"@opentelemetry/resources": "2.0.1",
+				"@opentelemetry/sdk-trace-base": "2.0.1"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
@@ -1700,46 +1390,15 @@
 				"@opentelemetry/api": "^1.3.0"
 			}
 		},
-		"node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/core": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-			"integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/resources": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
-			"integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.0.0",
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.3.0 <1.10.0"
-			}
-		},
 		"node_modules/@opentelemetry/exporter-zipkin": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-2.0.0.tgz",
-			"integrity": "sha512-icxaKZ+jZL/NHXX8Aru4HGsrdhK0MLcuRXkX5G5IRmCgoRLw+Br6I/nMVozX2xjGGwV7hw2g+4Slj8K7s4HbVg==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-2.0.1.tgz",
+			"integrity": "sha512-a9eeyHIipfdxzCfc2XPrE+/TI3wmrZUDFtG2RRXHSbZZULAny7SyybSvaDvS77a7iib5MPiAvluwVvbGTsHxsw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "2.0.0",
-				"@opentelemetry/resources": "2.0.0",
-				"@opentelemetry/sdk-trace-base": "2.0.0",
+				"@opentelemetry/core": "2.0.1",
+				"@opentelemetry/resources": "2.0.1",
+				"@opentelemetry/sdk-trace-base": "2.0.1",
 				"@opentelemetry/semantic-conventions": "^1.29.0"
 			},
 			"engines": {
@@ -1749,48 +1408,15 @@
 				"@opentelemetry/api": "^1.0.0"
 			}
 		},
-		"node_modules/@opentelemetry/exporter-zipkin/node_modules/@opentelemetry/core": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-			"integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/exporter-zipkin/node_modules/@opentelemetry/resources": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
-			"integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.0.0",
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.3.0 <1.10.0"
-			}
-		},
 		"node_modules/@opentelemetry/instrumentation": {
-			"version": "0.200.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.200.0.tgz",
-			"integrity": "sha512-pmPlzfJd+vvgaZd/reMsC8RWgTXn2WY1OWT5RT42m3aOn5532TozwXNDhg1vzqJ+jnvmkREcdLr27ebJEQt0Jg==",
+			"version": "0.203.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.203.0.tgz",
+			"integrity": "sha512-ke1qyM+3AK2zPuBPb6Hk/GCsc5ewbLvPNkEuELx/JmANeEp6ZjnZ+wypPAJSucTw0wvCGrUaibDSdcrGFoWxKQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/api-logs": "0.200.0",
-				"@types/shimmer": "^1.2.0",
+				"@opentelemetry/api-logs": "0.203.0",
 				"import-in-the-middle": "^1.8.1",
-				"require-in-the-middle": "^7.1.1",
-				"shimmer": "^1.2.1"
+				"require-in-the-middle": "^7.1.1"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
@@ -1800,13 +1426,13 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-amqplib": {
-			"version": "0.47.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.47.0.tgz",
-			"integrity": "sha512-bQboBxolOVDcD4l5QAwqKYpJVKQ8BW82+8tiD5uheu0hDuYgdmDziSAByc8yKS7xpkJw4AYocVP7JwSpQ1hgjg==",
+			"version": "0.50.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.50.0.tgz",
+			"integrity": "sha512-kwNs/itehHG/qaQBcVrLNcvXVPW0I4FCOVtw3LHMLdYIqD7GJ6Yv2nX+a4YHjzbzIeRYj8iyMp0Bl7tlkidq5w==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/core": "^2.0.0",
-				"@opentelemetry/instrumentation": "^0.200.0",
+				"@opentelemetry/instrumentation": "^0.203.0",
 				"@opentelemetry/semantic-conventions": "^1.27.0"
 			},
 			"engines": {
@@ -1817,14 +1443,14 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-aws-lambda": {
-			"version": "0.51.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.51.1.tgz",
-			"integrity": "sha512-DxUihz1ZcJtkCKFMnsr5IpQtU1TFnz/QhTEkcb95yfVvmdWx97ezbcxE4lGFjvQYMT8q2NsZjor8s8W/jrMU2w==",
+			"version": "0.54.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.54.1.tgz",
+			"integrity": "sha512-qm8pGSAM1mXk7unbrGktWWGJc6IFI58ZsaHJ+i420Fp5VO3Vf7GglIgaXTS8CKBrVB4LHFj3NvzJg31PtsAQcA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/instrumentation": "^0.200.0",
+				"@opentelemetry/instrumentation": "^0.203.0",
 				"@opentelemetry/semantic-conventions": "^1.27.0",
-				"@types/aws-lambda": "8.10.147"
+				"@types/aws-lambda": "8.10.152"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
@@ -1834,15 +1460,14 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-aws-sdk": {
-			"version": "0.52.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.52.0.tgz",
-			"integrity": "sha512-xMnghwQP/vO9hNNufaHW3SgNprifLPqmssAQ/zjRopbxa6wpBqunWfKYRRoyu89Xlw0X8/hGNoPEh+CIocCryg==",
+			"version": "0.58.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.58.0.tgz",
+			"integrity": "sha512-9vFH7gU686dsAeLMCkqUj9y0MQZ1xrTtStSpNV2UaGWtDnRjJrAdJLu9Y545oKEaDTeVaob4UflyZvvpZnw3Xw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/core": "^2.0.0",
-				"@opentelemetry/instrumentation": "^0.200.0",
-				"@opentelemetry/propagation-utils": "^0.31.0",
-				"@opentelemetry/semantic-conventions": "^1.27.0"
+				"@opentelemetry/instrumentation": "^0.203.0",
+				"@opentelemetry/semantic-conventions": "^1.34.0"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
@@ -1852,13 +1477,13 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-bunyan": {
-			"version": "0.46.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-bunyan/-/instrumentation-bunyan-0.46.0.tgz",
-			"integrity": "sha512-7ERXBAMIVi1rtFG5odsLTLVy6IJZnLLB74fFlPstV7/ZZG04UZ8YFOYVS14jXArcPohY8HFYLbm56dIFCXYI9w==",
+			"version": "0.49.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-bunyan/-/instrumentation-bunyan-0.49.0.tgz",
+			"integrity": "sha512-ky5Am1y6s3Ex/3RygHxB/ZXNG07zPfg9Z6Ora+vfeKcr/+I6CJbWXWhSBJor3gFgKN3RvC11UWVURnmDpBS6Pg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/api-logs": "^0.200.0",
-				"@opentelemetry/instrumentation": "^0.200.0",
+				"@opentelemetry/api-logs": "^0.203.0",
+				"@opentelemetry/instrumentation": "^0.203.0",
 				"@types/bunyan": "1.8.11"
 			},
 			"engines": {
@@ -1869,12 +1494,12 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-cassandra-driver": {
-			"version": "0.46.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cassandra-driver/-/instrumentation-cassandra-driver-0.46.0.tgz",
-			"integrity": "sha512-ItT2C32afignjHQosleI/iBjzlHhF+F7tJIK9ty47/CceVNlA9oK39ss9f7o9jmnKvQfhNWffvkXdjc0afwnSQ==",
+			"version": "0.49.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cassandra-driver/-/instrumentation-cassandra-driver-0.49.0.tgz",
+			"integrity": "sha512-BNIvqldmLkeikfI5w5Rlm9vG5NnQexfPoxOgEMzfDVOEF+vS6351I6DzWLLgWWR9CNF/jQJJi/lr6am2DLp0Rw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/instrumentation": "^0.200.0",
+				"@opentelemetry/instrumentation": "^0.203.0",
 				"@opentelemetry/semantic-conventions": "^1.27.0"
 			},
 			"engines": {
@@ -1885,13 +1510,13 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-connect": {
-			"version": "0.44.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.44.0.tgz",
-			"integrity": "sha512-eChFPViU/nkHsCYSp2PCnHnxt/ZmI/N5reHcwmjXbKhEj6TRNJcjLpI+OQksP8lLu0CS9DlDosHEhknCsxLdjQ==",
+			"version": "0.47.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.47.0.tgz",
+			"integrity": "sha512-pjenvjR6+PMRb6/4X85L4OtkQCootgb/Jzh/l/Utu3SJHBid1F+gk9sTGU2FWuhhEfV6P7MZ7BmCdHXQjgJ42g==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/core": "^2.0.0",
-				"@opentelemetry/instrumentation": "^0.200.0",
+				"@opentelemetry/instrumentation": "^0.203.0",
 				"@opentelemetry/semantic-conventions": "^1.27.0",
 				"@types/connect": "3.4.38"
 			},
@@ -1903,12 +1528,12 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-cucumber": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cucumber/-/instrumentation-cucumber-0.15.0.tgz",
-			"integrity": "sha512-MOHDzttn5TSBqt4j3/XjBhYNH0iLQP7oX2pumIzXP7dJFTcUtaq6PVakKPtIaqBTTabOKqCJhrF240XGwWefPQ==",
+			"version": "0.19.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cucumber/-/instrumentation-cucumber-0.19.0.tgz",
+			"integrity": "sha512-99ms8kQWRuPt5lkDqbJJzD+7Tq5TMUlBZki4SA2h6CgK4ncX+tyep9XFY1e+XTBLJIWmuFMGbWqBLJ4fSKIQNQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/instrumentation": "^0.200.0",
+				"@opentelemetry/instrumentation": "^0.203.0",
 				"@opentelemetry/semantic-conventions": "^1.27.0"
 			},
 			"engines": {
@@ -1919,12 +1544,12 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-dataloader": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.17.0.tgz",
-			"integrity": "sha512-JqovxOo7a65+3A/W+eiqUv7DrDsSvsY0NemHJ4uyVrzD4bpDYofVRdnz/ehYcNerlxVIKU+HcybDmiaoj41DPw==",
+			"version": "0.21.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.21.1.tgz",
+			"integrity": "sha512-hNAm/bwGawLM8VDjKR0ZUDJ/D/qKR3s6lA5NV+btNaPVm2acqhPcT47l2uCVi+70lng2mywfQncor9v8/ykuyw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/instrumentation": "^0.200.0"
+				"@opentelemetry/instrumentation": "^0.203.0"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
@@ -1934,12 +1559,12 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-dns": {
-			"version": "0.44.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.44.0.tgz",
-			"integrity": "sha512-+tAFXkFPldOpIba2akqKQ1ukqHET1pZ4pqhrr5x0p+RJ+1a1pPmTt1vCyvSSr634WOY8qMSmzZps++16yxnMbA==",
+			"version": "0.47.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.47.0.tgz",
+			"integrity": "sha512-775fOnewWkTF4iXMGKgwvOGqEmPrU1PZpXjjqvTrEErYBJe7Fz1WlEeUStHepyKOdld7Ghv7TOF/kE3QDctvrg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/instrumentation": "^0.200.0"
+				"@opentelemetry/instrumentation": "^0.203.0"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
@@ -1949,13 +1574,13 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-express": {
-			"version": "0.49.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.49.0.tgz",
-			"integrity": "sha512-j1hbIZzbu7jLQfI/Hz0wHDaniiSWdC3B8/UdH0CEd4lcO8y0pQlz4UTReBaL1BzbkwUhbg6oHuK+m8DXklQPtA==",
+			"version": "0.52.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.52.0.tgz",
+			"integrity": "sha512-W7pizN0Wh1/cbNhhTf7C62NpyYw7VfCFTYg0DYieSTrtPBT1vmoSZei19wfKLnrMsz3sHayCg0HxCVL2c+cz5w==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/core": "^2.0.0",
-				"@opentelemetry/instrumentation": "^0.200.0",
+				"@opentelemetry/instrumentation": "^0.203.0",
 				"@opentelemetry/semantic-conventions": "^1.27.0"
 			},
 			"engines": {
@@ -1966,13 +1591,13 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-fastify": {
-			"version": "0.45.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.45.0.tgz",
-			"integrity": "sha512-m94anTFZ6jpvK0G5fXIiq1sB0gCgY2rAL7Cg7svuOh9Roya2RIQz2E5KfCsO1kWCmnHNeTo7wIofoGN7WLPvsA==",
+			"version": "0.48.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.48.0.tgz",
+			"integrity": "sha512-3zQlE/DoVfVH6/ycuTv7vtR/xib6WOa0aLFfslYcvE62z0htRu/ot8PV/zmMZfnzpTQj8S/4ULv36R6UIbpJIg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/core": "^2.0.0",
-				"@opentelemetry/instrumentation": "^0.200.0",
+				"@opentelemetry/instrumentation": "^0.203.0",
 				"@opentelemetry/semantic-conventions": "^1.27.0"
 			},
 			"engines": {
@@ -1983,13 +1608,13 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-fs": {
-			"version": "0.20.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.20.0.tgz",
-			"integrity": "sha512-30l45ovjwHb16ImCGVjKCvw5U7X1zKuYY26ii5S+goV8BZ4a/TCpBf2kQxteQjWD05Gl3fzPMZI5aScfPI6Rjw==",
+			"version": "0.23.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.23.0.tgz",
+			"integrity": "sha512-Puan+QopWHA/KNYvDfOZN6M/JtF6buXEyD934vrb8WhsX1/FuM7OtoMlQyIqAadnE8FqqDL4KDPiEfCQH6pQcQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/core": "^2.0.0",
-				"@opentelemetry/instrumentation": "^0.200.0"
+				"@opentelemetry/instrumentation": "^0.203.0"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
@@ -1999,12 +1624,12 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-generic-pool": {
-			"version": "0.44.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.44.0.tgz",
-			"integrity": "sha512-bY7locZDqmQLEtY2fIJbSnAbHilxfhflaEQHjevFGkaiXc9UMtOvITOy5JKHhYQISpgrvY2WGXKG7YlVyI7uMg==",
+			"version": "0.47.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.47.0.tgz",
+			"integrity": "sha512-UfHqf3zYK+CwDwEtTjaD12uUqGGTswZ7ofLBEdQ4sEJp9GHSSJMQ2hT3pgBxyKADzUdoxQAv/7NqvL42ZI+Qbw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/instrumentation": "^0.200.0"
+				"@opentelemetry/instrumentation": "^0.203.0"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
@@ -2014,12 +1639,12 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-graphql": {
-			"version": "0.48.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.48.0.tgz",
-			"integrity": "sha512-w1sbf9F9bQTpIWGnKWhH1A+9N9rKxS4eM+AzczgMWp272ZM9lQv4zLTrH5NRST2ltY3nmZ72wkfFrSR0rECi0g==",
+			"version": "0.51.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.51.0.tgz",
+			"integrity": "sha512-LchkOu9X5DrXAnPI1+Z06h/EH/zC7D6sA86hhPrk3evLlsJTz0grPrkL/yUJM9Ty0CL/y2HSvmWQCjbJEz/ADg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/instrumentation": "^0.200.0"
+				"@opentelemetry/instrumentation": "^0.203.0"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
@@ -2029,12 +1654,12 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-grpc": {
-			"version": "0.200.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.200.0.tgz",
-			"integrity": "sha512-iaPHlO1qb1WlGUq0oTx0rJND/BtBeTAtyEfflu2VwKDe8XZeia7UEOfiSQxnGqVSTwW5F0P1S5UzqeDJotreWQ==",
+			"version": "0.203.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.203.0.tgz",
+			"integrity": "sha512-Qmjx2iwccHYRLoE4RFS46CvQE9JG9Pfeae4EPaNZjvIuJxb/pZa2R9VWzRlTehqQWpAvto/dGhtkw8Tv+o0LTg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/instrumentation": "0.200.0",
+				"@opentelemetry/instrumentation": "0.203.0",
 				"@opentelemetry/semantic-conventions": "^1.29.0"
 			},
 			"engines": {
@@ -2045,13 +1670,13 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-hapi": {
-			"version": "0.46.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.46.0.tgz",
-			"integrity": "sha512-573y+ZxywEcq+3+Z3KqcbV45lrVwUKvQiP9OhABVFNX8wHbtM6DPRBmYfqiUkSbIBcOEihm5qH6Gs73Xq0RBEA==",
+			"version": "0.50.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.50.0.tgz",
+			"integrity": "sha512-5xGusXOFQXKacrZmDbpHQzqYD1gIkrMWuwvlrEPkYOsjUqGUjl1HbxCsn5Y9bUXOCgP1Lj6A4PcKt1UiJ2MujA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/core": "^2.0.0",
-				"@opentelemetry/instrumentation": "^0.200.0",
+				"@opentelemetry/instrumentation": "^0.203.0",
 				"@opentelemetry/semantic-conventions": "^1.27.0"
 			},
 			"engines": {
@@ -2062,13 +1687,13 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-http": {
-			"version": "0.200.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.200.0.tgz",
-			"integrity": "sha512-9tqGbCJikhYU68y3k9mi6yWsMyMeCcwoQuHvIXan5VvvPPQ5WIZaV6Mxu/MCVe4swRNoFs8Th+qyj0TZV5ELvw==",
+			"version": "0.203.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.203.0.tgz",
+			"integrity": "sha512-y3uQAcCOAwnO6vEuNVocmpVzG3PER6/YZqbPbbffDdJ9te5NkHEkfSMNzlC3+v7KlE+WinPGc3N7MR30G1HY2g==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "2.0.0",
-				"@opentelemetry/instrumentation": "0.200.0",
+				"@opentelemetry/core": "2.0.1",
+				"@opentelemetry/instrumentation": "0.203.0",
 				"@opentelemetry/semantic-conventions": "^1.29.0",
 				"forwarded-parse": "2.1.2"
 			},
@@ -2079,29 +1704,14 @@
 				"@opentelemetry/api": "^1.3.0"
 			}
 		},
-		"node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/core": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-			"integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
 		"node_modules/@opentelemetry/instrumentation-ioredis": {
-			"version": "0.48.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.48.0.tgz",
-			"integrity": "sha512-kQhdrn/CAfJIObqbyyGtagWNxPvglJ9FwnWmsfXKodaGskJv/nyvdC9yIcgwzjbkG1pokVUROrvJ0mizqm29Tg==",
+			"version": "0.51.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.51.0.tgz",
+			"integrity": "sha512-9IUws0XWCb80NovS+17eONXsw1ZJbHwYYMXiwsfR9TSurkLV5UNbRSKb9URHO+K+pIJILy9wCxvyiOneMr91Ig==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/instrumentation": "^0.200.0",
-				"@opentelemetry/redis-common": "^0.37.0",
+				"@opentelemetry/instrumentation": "^0.203.0",
+				"@opentelemetry/redis-common": "^0.38.0",
 				"@opentelemetry/semantic-conventions": "^1.27.0"
 			},
 			"engines": {
@@ -2112,12 +1722,12 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-kafkajs": {
-			"version": "0.9.2",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.9.2.tgz",
-			"integrity": "sha512-aRnrLK3gQv6LP64oiXEDdRVwxNe7AvS98SCtNWEGhHy4nv3CdxpN7b7NU53g3PCF7uPQZ1fVW2C6Xc2tt1SIkg==",
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.13.0.tgz",
+			"integrity": "sha512-FPQyJsREOaGH64hcxlzTsIEQC4DYANgTwHjiB7z9lldmvua1LRMVn3/FfBlzXoqF179B0VGYviz6rn75E9wsDw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/instrumentation": "^0.200.0",
+				"@opentelemetry/instrumentation": "^0.203.0",
 				"@opentelemetry/semantic-conventions": "^1.30.0"
 			},
 			"engines": {
@@ -2128,13 +1738,13 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-knex": {
-			"version": "0.45.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.45.0.tgz",
-			"integrity": "sha512-2kkyTDUzK/3G3jxTc+NqHSdgi1Mjw2irZ98T/cSyNdlbsnDOMSTHjbm0AxJCV4QYQ4cKW7a8W/BBgxDGlu+mXQ==",
+			"version": "0.48.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.48.0.tgz",
+			"integrity": "sha512-V5wuaBPv/lwGxuHjC6Na2JFRjtPgstw19jTFl1B1b6zvaX8zVDYUDaR5hL7glnQtUSCMktPttQsgK4dhXpddcA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/instrumentation": "^0.200.0",
-				"@opentelemetry/semantic-conventions": "^1.27.0"
+				"@opentelemetry/instrumentation": "^0.203.0",
+				"@opentelemetry/semantic-conventions": "^1.33.1"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
@@ -2144,13 +1754,13 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-koa": {
-			"version": "0.48.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.48.0.tgz",
-			"integrity": "sha512-LV63v3pxFpjKC0IJO+y5nsGdcH+9Y8Wnn0fhu673XZ5auxqJk2t4nIHuSmls08oRKaX+5q1e+h70XmP/45NJsw==",
+			"version": "0.51.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.51.0.tgz",
+			"integrity": "sha512-XNLWeMTMG1/EkQBbgPYzCeBD0cwOrfnn8ao4hWgLv0fNCFQu1kCsJYygz2cvKuCs340RlnG4i321hX7R8gj3Rg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/core": "^2.0.0",
-				"@opentelemetry/instrumentation": "^0.200.0",
+				"@opentelemetry/instrumentation": "^0.203.0",
 				"@opentelemetry/semantic-conventions": "^1.27.0"
 			},
 			"engines": {
@@ -2161,12 +1771,12 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-lru-memoizer": {
-			"version": "0.45.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.45.0.tgz",
-			"integrity": "sha512-W2MNx7hPtvSIgEFxFrqdBykdfN0UrShCbJxvMU9fwgqbOdxIrcubPt0i1vmy3Ap6QwSi+HmsRNQD2w3ucbLG3A==",
+			"version": "0.48.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.48.0.tgz",
+			"integrity": "sha512-KUW29wfMlTPX1wFz+NNrmE7IzN7NWZDrmFWHM/VJcmFEuQGnnBuTIdsP55CnBDxKgQ/qqYFp4udQFNtjeFosPw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/instrumentation": "^0.200.0"
+				"@opentelemetry/instrumentation": "^0.203.0"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
@@ -2176,12 +1786,12 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-memcached": {
-			"version": "0.44.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-memcached/-/instrumentation-memcached-0.44.0.tgz",
-			"integrity": "sha512-1zABdJlF9Tk0yUv2ELpF6Mk2kw81k+bnB3Sw+D/ssRDcGGCnCNbz+fKJE8dwAPkDP+OcTmiKm6ySREbcyRFzCg==",
+			"version": "0.47.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-memcached/-/instrumentation-memcached-0.47.0.tgz",
+			"integrity": "sha512-vXDs/l4hlWy1IepPG1S6aYiIZn+tZDI24kAzwKKJmR2QEJRL84PojmALAEJGazIOLl/VdcCPZdMb0U2K0VzojA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/instrumentation": "^0.200.0",
+				"@opentelemetry/instrumentation": "^0.203.0",
 				"@opentelemetry/semantic-conventions": "^1.27.0",
 				"@types/memcached": "^2.2.6"
 			},
@@ -2193,12 +1803,12 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-mongodb": {
-			"version": "0.53.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.53.0.tgz",
-			"integrity": "sha512-zS2gQJQuG7RZw5yaNG/TnxsOtv1fFkn3ypuDrVLJtJLZtcOr4GYn31jbIA8od+QW/ChZLVcH364iDs+z/xS9wA==",
+			"version": "0.56.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.56.0.tgz",
+			"integrity": "sha512-YG5IXUUmxX3Md2buVMvxm9NWlKADrnavI36hbJsihqqvBGsWnIfguf0rUP5Srr0pfPqhQjUP+agLMsvu0GmUpA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/instrumentation": "^0.200.0",
+				"@opentelemetry/instrumentation": "^0.203.0",
 				"@opentelemetry/semantic-conventions": "^1.27.0"
 			},
 			"engines": {
@@ -2209,13 +1819,13 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-mongoose": {
-			"version": "0.47.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.47.1.tgz",
-			"integrity": "sha512-0OcL5YpZX9PtF55Oi1RtWUdjElJscR9u6NzAdww81EQc3wFfQWmdREUEBeWaDH5jpiomdFp6zDXms622ofEOjg==",
+			"version": "0.50.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.50.0.tgz",
+			"integrity": "sha512-Am8pk1Ct951r4qCiqkBcGmPIgGhoDiFcRtqPSLbJrUZqEPUsigjtMjoWDRLG1Ki1NHgOF7D0H7d+suWz1AAizw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/core": "^2.0.0",
-				"@opentelemetry/instrumentation": "^0.200.0",
+				"@opentelemetry/instrumentation": "^0.203.0",
 				"@opentelemetry/semantic-conventions": "^1.27.0"
 			},
 			"engines": {
@@ -2226,14 +1836,14 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-mysql": {
-			"version": "0.46.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.46.0.tgz",
-			"integrity": "sha512-Z1NDAv07suIukgL7kxk9cAQX1t/smRMLNOU+q5Aqnhnf/0FIF/N4cX2wg+25IWy0m2PoaPbAVYCKB0aOt5vzAw==",
+			"version": "0.49.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.49.0.tgz",
+			"integrity": "sha512-QU9IUNqNsrlfE3dJkZnFHqLjlndiU39ll/YAAEvWE40sGOCi9AtOF6rmEGzJ1IswoZ3oyePV7q2MP8SrhJfVAA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/instrumentation": "^0.200.0",
+				"@opentelemetry/instrumentation": "^0.203.0",
 				"@opentelemetry/semantic-conventions": "^1.27.0",
-				"@types/mysql": "2.15.26"
+				"@types/mysql": "2.15.27"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
@@ -2243,12 +1853,12 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-mysql2": {
-			"version": "0.46.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.46.0.tgz",
-			"integrity": "sha512-JsmIA+aTfHqy2tahjnVWChRipYpYrTy+XFAuUPia9CTaspCx8ZrirPUqYnbnaPEtnzYff2a4LX0B2LT1hKlOiA==",
+			"version": "0.50.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.50.0.tgz",
+			"integrity": "sha512-PoOMpmq73rOIE3nlTNLf3B1SyNYGsp7QXHYKmeTZZnJ2Ou7/fdURuOhWOI0e6QZ5gSem18IR1sJi6GOULBQJ9g==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/instrumentation": "^0.200.0",
+				"@opentelemetry/instrumentation": "^0.203.0",
 				"@opentelemetry/semantic-conventions": "^1.27.0",
 				"@opentelemetry/sql-common": "^0.41.0"
 			},
@@ -2260,12 +1870,12 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-nestjs-core": {
-			"version": "0.46.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.46.0.tgz",
-			"integrity": "sha512-5cYnBIMZuTSLFUt0pMH+NQNdI5/2YeCVuz29Mo2lkudbBUOvzGmzl/Y6LG1JEw2j6zuJx5IgO5CKNrJqAIzTWA==",
+			"version": "0.49.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.49.0.tgz",
+			"integrity": "sha512-1R/JFwdmZIk3T/cPOCkVvFQeKYzbbUvDxVH3ShXamUwBlGkdEu5QJitlRMyVNZaHkKZKWgYrBarGQsqcboYgaw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/instrumentation": "^0.200.0",
+				"@opentelemetry/instrumentation": "^0.203.0",
 				"@opentelemetry/semantic-conventions": "^1.30.0"
 			},
 			"engines": {
@@ -2276,12 +1886,12 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-net": {
-			"version": "0.44.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-net/-/instrumentation-net-0.44.0.tgz",
-			"integrity": "sha512-SmAbOKTi0lgdTN9XMXOaf+4jw670MpiK3pw9/to/kRlTvNWwWA4RD34trCcoL7Gf2IYoXuj56Oo4Z5C7N98ukw==",
+			"version": "0.47.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-net/-/instrumentation-net-0.47.0.tgz",
+			"integrity": "sha512-csoJ++Njpf7C09JH+0HNGenuNbDZBqO1rFhMRo6s0rAmJwNh9zY3M/urzptmKlqbKnf4eH0s+CKHy/+M8fbFsQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/instrumentation": "^0.200.0",
+				"@opentelemetry/instrumentation": "^0.203.0",
 				"@opentelemetry/semantic-conventions": "^1.27.0"
 			},
 			"engines": {
@@ -2291,17 +1901,34 @@
 				"@opentelemetry/api": "^1.3.0"
 			}
 		},
+		"node_modules/@opentelemetry/instrumentation-oracledb": {
+			"version": "0.29.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-oracledb/-/instrumentation-oracledb-0.29.0.tgz",
+			"integrity": "sha512-2aHLiJdkyiUbooIUm7FaZf+O4jyqEl+RfFpgud1dxT87QeeYM216wi+xaMNzsb5yKtRBqbA3qeHBCyenYrOZwA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/instrumentation": "^0.203.0",
+				"@opentelemetry/semantic-conventions": "^1.27.0",
+				"@types/oracledb": "6.5.2"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
 		"node_modules/@opentelemetry/instrumentation-pg": {
-			"version": "0.52.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.52.0.tgz",
-			"integrity": "sha512-OBpqlxTqmFkZGHaHV4Pzd95HkyKVS+vf0N5wVX3BSb8uqsvOrW62I1qt+2jNsZ13dtG5eOzvcsQTMGND76wizA==",
+			"version": "0.56.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.56.1.tgz",
+			"integrity": "sha512-0/PiHDPVaLdcXNw6Gqb3JBdMxComMEwh444X8glwiynJKJHRTR49+l2cqJfoOVzB8Sl1XRl3Yaqw6aDi3s8e9w==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/core": "^2.0.0",
-				"@opentelemetry/instrumentation": "^0.200.0",
-				"@opentelemetry/semantic-conventions": "^1.27.0",
+				"@opentelemetry/instrumentation": "^0.203.0",
+				"@opentelemetry/semantic-conventions": "^1.34.0",
 				"@opentelemetry/sql-common": "^0.41.0",
-				"@types/pg": "8.6.1",
+				"@types/pg": "8.15.5",
 				"@types/pg-pool": "2.0.6"
 			},
 			"engines": {
@@ -2312,14 +1939,14 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-pino": {
-			"version": "0.47.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.47.0.tgz",
-			"integrity": "sha512-OFOy/TGtGXMYWrF4xPKhLN1evdqUpbuoKODzeh3GSjFkcooZZf4m/Hpzu12FV+s0wDBf43oAjXbNJWeCJQMrug==",
+			"version": "0.50.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.50.1.tgz",
+			"integrity": "sha512-pBbvuWiHA9iAumAuQ0SKYOXK7NRlbnVTf/qBV0nMdRnxBPrc/GZTbh0f7Y59gZfYsbCLhXLL1oRTEnS+PwS3CA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/api-logs": "^0.200.0",
+				"@opentelemetry/api-logs": "^0.203.0",
 				"@opentelemetry/core": "^2.0.0",
-				"@opentelemetry/instrumentation": "^0.200.0"
+				"@opentelemetry/instrumentation": "^0.203.0"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
@@ -2329,30 +1956,13 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-redis": {
-			"version": "0.47.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.47.0.tgz",
-			"integrity": "sha512-T2YvuX/LaJEQKgKvIQJlbSMSzxp6oBm+9PMgfn7QcBXzSY9tyeyDF6QjLAKNvxs+BJeQzFmDlahjoEyatzxRWA==",
+			"version": "0.52.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.52.0.tgz",
+			"integrity": "sha512-R8Y7cCZlJ2Vl31S2i7bl5SqyC/aul54ski4wCFip/Tp9WGtLK1xVATi2rwy2wkc8ZCtjdEe9eEVR+QFG6gGZxg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/instrumentation": "^0.200.0",
-				"@opentelemetry/redis-common": "^0.37.0",
-				"@opentelemetry/semantic-conventions": "^1.27.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": "^1.3.0"
-			}
-		},
-		"node_modules/@opentelemetry/instrumentation-redis-4": {
-			"version": "0.47.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.47.0.tgz",
-			"integrity": "sha512-9LywJGp1fmmLj6g1+Rv91pVE3ATle1C/qIya9ZLwPywXTOdFIARI/gvvvlI7uFABoLojj2dSaI/5JQrq4C1HSg==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/instrumentation": "^0.200.0",
-				"@opentelemetry/redis-common": "^0.37.0",
+				"@opentelemetry/instrumentation": "^0.203.0",
+				"@opentelemetry/redis-common": "^0.38.0",
 				"@opentelemetry/semantic-conventions": "^1.27.0"
 			},
 			"engines": {
@@ -2363,13 +1973,13 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-restify": {
-			"version": "0.46.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.46.0.tgz",
-			"integrity": "sha512-du1FjKsTGQH6q8QjG0Bxlg0L79Co/Ey0btKKb2sg7fvg0YX6LKdR2N1fzfne/A9k+WjQ5v28JuUXOk2cEPYU/Q==",
+			"version": "0.49.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.49.0.tgz",
+			"integrity": "sha512-tsGZZhS4mVZH7omYxw5jpsrD3LhWizqWc0PYtAnzpFUvL5ZINHE+cm57bssTQ2AK/GtZMxu9LktwCvIIf3dSmw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/core": "^2.0.0",
-				"@opentelemetry/instrumentation": "^0.200.0",
+				"@opentelemetry/instrumentation": "^0.203.0",
 				"@opentelemetry/semantic-conventions": "^1.27.0"
 			},
 			"engines": {
@@ -2380,12 +1990,12 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-router": {
-			"version": "0.45.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-router/-/instrumentation-router-0.45.0.tgz",
-			"integrity": "sha512-CGEeT73Wy/nLQw+obG/mBCIgMbZQKrGG6hzbEdtQ4G2jqI97w7pLWdM4DvkpWVBNcxMpO13dX1nn2OiyZXND3Q==",
+			"version": "0.48.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-router/-/instrumentation-router-0.48.0.tgz",
+			"integrity": "sha512-Wixrc8CchuJojXpaS/dCQjFOMc+3OEil1H21G+WLYQb8PcKt5kzW9zDBT19nyjjQOx/D/uHPfgbrT+Dc7cfJ9w==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/instrumentation": "^0.200.0",
+				"@opentelemetry/instrumentation": "^0.203.0",
 				"@opentelemetry/semantic-conventions": "^1.27.0"
 			},
 			"engines": {
@@ -2396,12 +2006,12 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-runtime-node": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-runtime-node/-/instrumentation-runtime-node-0.14.0.tgz",
-			"integrity": "sha512-y78dGoFMKwHSz0SD113Gt1dFTcfunpPZXIJh2SzJN27Lyb9FIzuMfjc3Iu3+s/N6qNOLuS9mKnPe3/qVGG4Waw==",
+			"version": "0.17.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-runtime-node/-/instrumentation-runtime-node-0.17.1.tgz",
+			"integrity": "sha512-c1FlAk+bB2uF9a8YneGmNPTl7c/xVaan4mmWvbkWcOmH/ipKqR1LaKUlz/BMzLrJLjho1EJlG2NrS2w2Arg+nw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/instrumentation": "^0.200.0"
+				"@opentelemetry/instrumentation": "^0.203.0"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
@@ -2411,12 +2021,12 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-socket.io": {
-			"version": "0.47.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-socket.io/-/instrumentation-socket.io-0.47.0.tgz",
-			"integrity": "sha512-qAc+XCcRmZYjs8KJIPv+MMR2wPPPOppwoarzKRR4G+yvOBs1xMwbbkqNHifKga0XcfFX4KVr7Z5QQ6ZZzWyLtg==",
+			"version": "0.50.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-socket.io/-/instrumentation-socket.io-0.50.0.tgz",
+			"integrity": "sha512-6JN6lnKN9ZuZtZdMQIR+no1qHzQvXSZUsNe3sSWMgqmNRyEXuDUWBIyKKeG0oHRHtR4xE4QhJyD4D5kKRPWZFA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/instrumentation": "^0.200.0",
+				"@opentelemetry/instrumentation": "^0.203.0",
 				"@opentelemetry/semantic-conventions": "^1.27.0"
 			},
 			"engines": {
@@ -2427,12 +2037,12 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-tedious": {
-			"version": "0.19.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.19.0.tgz",
-			"integrity": "sha512-hNC/Bz+g4RvwaKsbA1VD+9x8X2Ml+fN2uba4dniIdQIrAItLdet4xx/7TEoWYtyVJQozphvpnIsUp52Rw4djCA==",
+			"version": "0.22.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.22.0.tgz",
+			"integrity": "sha512-XrrNSUCyEjH1ax9t+Uo6lv0S2FCCykcF7hSxBMxKf7Xn0bPRxD3KyFUZy25aQXzbbbUHhtdxj3r2h88SfEM3aA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/instrumentation": "^0.200.0",
+				"@opentelemetry/instrumentation": "^0.203.0",
 				"@opentelemetry/semantic-conventions": "^1.27.0",
 				"@types/tedious": "^4.0.14"
 			},
@@ -2444,13 +2054,13 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-undici": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.11.0.tgz",
-			"integrity": "sha512-H6ijJnKVZBB0Lhm6NsaBt0rUz+i52LriLhrpGAE8SazB0jCIVY4MrL2dNib/4w8zA+Fw9zFwERJvKXUIbSD1ew==",
+			"version": "0.14.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.14.0.tgz",
+			"integrity": "sha512-2HN+7ztxAReXuxzrtA3WboAKlfP5OsPA57KQn2AdYZbJ3zeRPcLXyW4uO/jpLE6PLm0QRtmeGCmfYpqRlwgSwg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/core": "^2.0.0",
-				"@opentelemetry/instrumentation": "^0.200.0"
+				"@opentelemetry/instrumentation": "^0.203.0"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
@@ -2460,13 +2070,13 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-winston": {
-			"version": "0.45.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-winston/-/instrumentation-winston-0.45.0.tgz",
-			"integrity": "sha512-LZz3/6QvzoneSqD/xnB8wq/g1fy8oe2PwfZ15zS2YA5mnjuSqlqgl+k3sib7wfIYHMP1D3ajfbDB6UOJBALj/w==",
+			"version": "0.48.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-winston/-/instrumentation-winston-0.48.1.tgz",
+			"integrity": "sha512-XyOuVwdziirHHYlsw+BWrvdI/ymjwnexupKA787zQQ+D5upaE/tseZxjfQa7+t4+FdVLxHICaMTmkSD4yZHpzQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/api-logs": "^0.200.0",
-				"@opentelemetry/instrumentation": "^0.200.0"
+				"@opentelemetry/api-logs": "^0.203.0",
+				"@opentelemetry/instrumentation": "^0.203.0"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
@@ -2476,46 +2086,31 @@
 			}
 		},
 		"node_modules/@opentelemetry/otlp-exporter-base": {
-			"version": "0.200.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.200.0.tgz",
-			"integrity": "sha512-IxJgA3FD7q4V6gGq4bnmQM5nTIyMDkoGFGrBrrDjB6onEiq1pafma55V+bHvGYLWvcqbBbRfezr1GED88lacEQ==",
+			"version": "0.203.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.203.0.tgz",
+			"integrity": "sha512-Wbxf7k+87KyvxFr5D7uOiSq/vHXWommvdnNE7vECO3tAhsA2GfOlpWINCMWUEPdHZ7tCXxw6Epp3vgx3jU7llQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "2.0.0",
-				"@opentelemetry/otlp-transformer": "0.200.0"
+				"@opentelemetry/core": "2.0.1",
+				"@opentelemetry/otlp-transformer": "0.203.0"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.3.0"
-			}
-		},
-		"node_modules/@opentelemetry/otlp-exporter-base/node_modules/@opentelemetry/core": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-			"integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
 			}
 		},
 		"node_modules/@opentelemetry/otlp-grpc-exporter-base": {
-			"version": "0.200.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.200.0.tgz",
-			"integrity": "sha512-CK2S+bFgOZ66Bsu5hlDeOX6cvW5FVtVjFFbWuaJP0ELxJKBB6HlbLZQ2phqz/uLj1cWap5xJr/PsR3iGoB7Vqw==",
+			"version": "0.203.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.203.0.tgz",
+			"integrity": "sha512-te0Ze1ueJF+N/UOFl5jElJW4U0pZXQ8QklgSfJ2linHN0JJsuaHG8IabEUi2iqxY8ZBDlSiz1Trfv5JcjWWWwQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@grpc/grpc-js": "^1.7.1",
-				"@opentelemetry/core": "2.0.0",
-				"@opentelemetry/otlp-exporter-base": "0.200.0",
-				"@opentelemetry/otlp-transformer": "0.200.0"
+				"@opentelemetry/core": "2.0.1",
+				"@opentelemetry/otlp-exporter-base": "0.203.0",
+				"@opentelemetry/otlp-transformer": "0.203.0"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
@@ -2524,33 +2119,18 @@
 				"@opentelemetry/api": "^1.3.0"
 			}
 		},
-		"node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/core": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-			"integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
 		"node_modules/@opentelemetry/otlp-transformer": {
-			"version": "0.200.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.200.0.tgz",
-			"integrity": "sha512-+9YDZbYybOnv7sWzebWOeK6gKyt2XE7iarSyBFkwwnP559pEevKOUD8NyDHhRjCSp13ybh9iVXlMfcj/DwF/yw==",
+			"version": "0.203.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.203.0.tgz",
+			"integrity": "sha512-Y8I6GgoCna0qDQ2W6GCRtaF24SnvqvA8OfeTi7fqigD23u8Jpb4R5KFv/pRvrlGagcCLICMIyh9wiejp4TXu/A==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/api-logs": "0.200.0",
-				"@opentelemetry/core": "2.0.0",
-				"@opentelemetry/resources": "2.0.0",
-				"@opentelemetry/sdk-logs": "0.200.0",
-				"@opentelemetry/sdk-metrics": "2.0.0",
-				"@opentelemetry/sdk-trace-base": "2.0.0",
+				"@opentelemetry/api-logs": "0.203.0",
+				"@opentelemetry/core": "2.0.1",
+				"@opentelemetry/resources": "2.0.1",
+				"@opentelemetry/sdk-logs": "0.203.0",
+				"@opentelemetry/sdk-metrics": "2.0.1",
+				"@opentelemetry/sdk-trace-base": "2.0.1",
 				"protobufjs": "^7.3.0"
 			},
 			"engines": {
@@ -2560,87 +2140,13 @@
 				"@opentelemetry/api": "^1.3.0"
 			}
 		},
-		"node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/core": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-			"integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
-			"integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.0.0",
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.3.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-metrics": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.0.0.tgz",
-			"integrity": "sha512-Bvy8QDjO05umd0+j+gDeWcTaVa1/R2lDj/eOvjzpm8VQj1K1vVZJuyjThpV5/lSHyYW2JaHF2IQ7Z8twJFAhjA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.0.0",
-				"@opentelemetry/resources": "2.0.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.9.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/propagation-utils": {
-			"version": "0.31.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/propagation-utils/-/propagation-utils-0.31.1.tgz",
-			"integrity": "sha512-YLNt7SWy4HZwI9d+4+OevQs2Gmof27TkjR3v029UGw8zFOcyONyIQhHHx7doyRbrLpWZtUc91cnCA4mKhArCXw==",
-			"license": "Apache-2.0",
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.0"
-			}
-		},
 		"node_modules/@opentelemetry/propagator-b3": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-2.0.0.tgz",
-			"integrity": "sha512-blx9S2EI49Ycuw6VZq+bkpaIoiJFhsDuvFGhBIoH3vJ5oYjJ2U0s3fAM5jYft99xVIAv6HqoPtlP9gpVA2IZtA==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-2.0.1.tgz",
+			"integrity": "sha512-Hc09CaQ8Tf5AGLmf449H726uRoBNGPBL4bjr7AnnUpzWMvhdn61F78z9qb6IqB737TffBsokGAK1XykFEZ1igw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "2.0.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/propagator-b3/node_modules/@opentelemetry/core": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-			"integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "^1.29.0"
+				"@opentelemetry/core": "2.0.1"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
@@ -2650,27 +2156,12 @@
 			}
 		},
 		"node_modules/@opentelemetry/propagator-jaeger": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-2.0.0.tgz",
-			"integrity": "sha512-Mbm/LSFyAtQKP0AQah4AfGgsD+vsZcyreZoQ5okFBk33hU7AquU4TltgyL9dvaO8/Zkoud8/0gEvwfOZ5d7EPA==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-2.0.1.tgz",
+			"integrity": "sha512-7PMdPBmGVH2eQNb/AtSJizQNgeNTfh6jQFqys6lfhd6P4r+m/nTh3gKPPpaCXVdRQ+z93vfKk+4UGty390283w==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "2.0.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/propagator-jaeger/node_modules/@opentelemetry/core": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-			"integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "^1.29.0"
+				"@opentelemetry/core": "2.0.1"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
@@ -2680,18 +2171,18 @@
 			}
 		},
 		"node_modules/@opentelemetry/redis-common": {
-			"version": "0.37.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.37.0.tgz",
-			"integrity": "sha512-tJwgE6jt32bLs/9J6jhQRKU2EZnsD8qaO13aoFyXwF6s4LhpT7YFHf3Z03MqdILk6BA2BFUhoyh7k9fj9i032A==",
+			"version": "0.38.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.38.0.tgz",
+			"integrity": "sha512-4Wc0AWURII2cfXVVoZ6vDqK+s5n4K5IssdrlVrvGsx6OEOKdghKtJZqXAHWFiZv4nTDLH2/2fldjIHY8clMOjQ==",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
 			}
 		},
 		"node_modules/@opentelemetry/resource-detector-alibaba-cloud": {
-			"version": "0.31.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-alibaba-cloud/-/resource-detector-alibaba-cloud-0.31.1.tgz",
-			"integrity": "sha512-RPitvB5oHZsECnK7xtUAFdyBXRdtJbY0eEzQPBrLMQv4l/FN4pETijqv6LcKBbn6tevaoBU2bqOGnVoL4uX4Tg==",
+			"version": "0.31.3",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-alibaba-cloud/-/resource-detector-alibaba-cloud-0.31.3.tgz",
+			"integrity": "sha512-I556LHcLVsBXEgnbPgQISP/JezDt5OfpgOaJNR1iVJl202r+K145OSSOxnH5YOc/KvrydBD0FOE03F7x0xnVTw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/core": "^2.0.0",
@@ -2706,9 +2197,9 @@
 			}
 		},
 		"node_modules/@opentelemetry/resource-detector-aws": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-2.1.0.tgz",
-			"integrity": "sha512-7QG5wQXMiHseKIyU69m8vfZgLhrxFx48DdyaQEYj6GXjE/Xrv1nS3bUwhICjb6+4NorB9+1pFCvJ/4S01CCCjQ==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-2.3.0.tgz",
+			"integrity": "sha512-PkD/lyXG3B3REq1Y6imBLckljkJYXavtqGYSryAeJYvGOf5Ds3doR+BCGjmKeF6ObAtI5MtpBeUStTDtGtBsWA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/core": "^2.0.0",
@@ -2723,9 +2214,9 @@
 			}
 		},
 		"node_modules/@opentelemetry/resource-detector-azure": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-azure/-/resource-detector-azure-0.7.0.tgz",
-			"integrity": "sha512-aR2ALsK+b/+5lLDhK9KTK8rcuKg7+sqa/Cg+QCeasqoy7qby70FRtAbQcZGljJ5BLBcVPYjl1hcTYIUyL3Laww==",
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-azure/-/resource-detector-azure-0.10.0.tgz",
+			"integrity": "sha512-5cNAiyPBg53Uxe/CW7hsCq8HiKNAUGH+gi65TtgpzSR9bhJG4AEbuZhbJDFwe97tn2ifAD1JTkbc/OFuaaFWbA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/core": "^2.0.0",
@@ -2740,9 +2231,9 @@
 			}
 		},
 		"node_modules/@opentelemetry/resource-detector-container": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-container/-/resource-detector-container-0.7.1.tgz",
-			"integrity": "sha512-I2vXgdA8mhIlAktIp7NovicalqKPaas9APH5wQxIzMK6jPjZmwS5x0MBW+sTsaFM4pnOf/Md9enoDnnR5CLq5A==",
+			"version": "0.7.3",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-container/-/resource-detector-container-0.7.3.tgz",
+			"integrity": "sha512-SK+xUFw6DKYbQniaGmIFsFxAZsr8RpRSRWxKi5/ZJAoqqPnjcyGI/SeUx8zzPk4XLO084zyM4pRHgir0hRTaSQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/core": "^2.0.0",
@@ -2757,9 +2248,9 @@
 			}
 		},
 		"node_modules/@opentelemetry/resource-detector-gcp": {
-			"version": "0.34.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-gcp/-/resource-detector-gcp-0.34.0.tgz",
-			"integrity": "sha512-Mug9Oing1nVQE8pYT33UKuPSEa/wjQTMk3feS9F84h4U7oZIx5Mz3yddj3OHOPgrW/7d1Ve/mG7jmYqBI9tpTg==",
+			"version": "0.37.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-gcp/-/resource-detector-gcp-0.37.0.tgz",
+			"integrity": "sha512-LGpJBECIMsVKhiulb4nxUw++m1oF4EiDDPmFGW2aqYaAF0oUvJNv8Z/55CAzcZ7SxvlTgUwzewXDBsuCup7iqw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/core": "^2.0.0",
@@ -2791,51 +2282,20 @@
 			}
 		},
 		"node_modules/@opentelemetry/sdk-logs": {
-			"version": "0.200.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.200.0.tgz",
-			"integrity": "sha512-VZG870063NLfObmQQNtCVcdXXLzI3vOjjrRENmU37HYiPFa0ZXpXVDsTD02Nh3AT3xYJzQaWKl2X2lQ2l7TWJA==",
+			"version": "0.203.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.203.0.tgz",
+			"integrity": "sha512-vM2+rPq0Vi3nYA5akQD2f3QwossDnTDLvKbea6u/A2NZ3XDkPxMfo/PNrDoXhDUD/0pPo2CdH5ce/thn9K0kLw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/api-logs": "0.200.0",
-				"@opentelemetry/core": "2.0.0",
-				"@opentelemetry/resources": "2.0.0"
+				"@opentelemetry/api-logs": "0.203.0",
+				"@opentelemetry/core": "2.0.1",
+				"@opentelemetry/resources": "2.0.1"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": ">=1.4.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/core": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-			"integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
-			"integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.0.0",
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.3.0 <1.10.0"
 			}
 		},
 		"node_modules/@opentelemetry/sdk-metrics": {
@@ -2855,32 +2315,32 @@
 			}
 		},
 		"node_modules/@opentelemetry/sdk-node": {
-			"version": "0.200.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.200.0.tgz",
-			"integrity": "sha512-S/YSy9GIswnhYoDor1RusNkmRughipvTCOQrlF1dzI70yQaf68qgf5WMnzUxdlCl3/et/pvaO75xfPfuEmCK5A==",
+			"version": "0.203.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.203.0.tgz",
+			"integrity": "sha512-zRMvrZGhGVMvAbbjiNQW3eKzW/073dlrSiAKPVWmkoQzah9wfynpVPeL55f9fVIm0GaBxTLcPeukWGy0/Wj7KQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/api-logs": "0.200.0",
-				"@opentelemetry/core": "2.0.0",
-				"@opentelemetry/exporter-logs-otlp-grpc": "0.200.0",
-				"@opentelemetry/exporter-logs-otlp-http": "0.200.0",
-				"@opentelemetry/exporter-logs-otlp-proto": "0.200.0",
-				"@opentelemetry/exporter-metrics-otlp-grpc": "0.200.0",
-				"@opentelemetry/exporter-metrics-otlp-http": "0.200.0",
-				"@opentelemetry/exporter-metrics-otlp-proto": "0.200.0",
-				"@opentelemetry/exporter-prometheus": "0.200.0",
-				"@opentelemetry/exporter-trace-otlp-grpc": "0.200.0",
-				"@opentelemetry/exporter-trace-otlp-http": "0.200.0",
-				"@opentelemetry/exporter-trace-otlp-proto": "0.200.0",
-				"@opentelemetry/exporter-zipkin": "2.0.0",
-				"@opentelemetry/instrumentation": "0.200.0",
-				"@opentelemetry/propagator-b3": "2.0.0",
-				"@opentelemetry/propagator-jaeger": "2.0.0",
-				"@opentelemetry/resources": "2.0.0",
-				"@opentelemetry/sdk-logs": "0.200.0",
-				"@opentelemetry/sdk-metrics": "2.0.0",
-				"@opentelemetry/sdk-trace-base": "2.0.0",
-				"@opentelemetry/sdk-trace-node": "2.0.0",
+				"@opentelemetry/api-logs": "0.203.0",
+				"@opentelemetry/core": "2.0.1",
+				"@opentelemetry/exporter-logs-otlp-grpc": "0.203.0",
+				"@opentelemetry/exporter-logs-otlp-http": "0.203.0",
+				"@opentelemetry/exporter-logs-otlp-proto": "0.203.0",
+				"@opentelemetry/exporter-metrics-otlp-grpc": "0.203.0",
+				"@opentelemetry/exporter-metrics-otlp-http": "0.203.0",
+				"@opentelemetry/exporter-metrics-otlp-proto": "0.203.0",
+				"@opentelemetry/exporter-prometheus": "0.203.0",
+				"@opentelemetry/exporter-trace-otlp-grpc": "0.203.0",
+				"@opentelemetry/exporter-trace-otlp-http": "0.203.0",
+				"@opentelemetry/exporter-trace-otlp-proto": "0.203.0",
+				"@opentelemetry/exporter-zipkin": "2.0.1",
+				"@opentelemetry/instrumentation": "0.203.0",
+				"@opentelemetry/propagator-b3": "2.0.1",
+				"@opentelemetry/propagator-jaeger": "2.0.1",
+				"@opentelemetry/resources": "2.0.1",
+				"@opentelemetry/sdk-logs": "0.203.0",
+				"@opentelemetry/sdk-metrics": "2.0.1",
+				"@opentelemetry/sdk-trace-base": "2.0.1",
+				"@opentelemetry/sdk-trace-node": "2.0.1",
 				"@opentelemetry/semantic-conventions": "^1.29.0"
 			},
 			"engines": {
@@ -2888,123 +2348,16 @@
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": ">=1.3.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/context-async-hooks": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.0.0.tgz",
-			"integrity": "sha512-IEkJGzK1A9v3/EHjXh3s2IiFc6L4jfK+lNgKVgUjeUJQRRhnVFMIO3TAvKwonm9O1HebCuoOt98v8bZW7oVQHA==",
-			"license": "Apache-2.0",
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/core": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-			"integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/resources": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
-			"integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.0.0",
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.3.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/sdk-metrics": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.0.0.tgz",
-			"integrity": "sha512-Bvy8QDjO05umd0+j+gDeWcTaVa1/R2lDj/eOvjzpm8VQj1K1vVZJuyjThpV5/lSHyYW2JaHF2IQ7Z8twJFAhjA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.0.0",
-				"@opentelemetry/resources": "2.0.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.9.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/sdk-trace-node": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.0.0.tgz",
-			"integrity": "sha512-omdilCZozUjQwY3uZRBwbaRMJ3p09l4t187Lsdf0dGMye9WKD4NGcpgZRvqhI1dwcH6og+YXQEtoO9Wx3ykilg==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/context-async-hooks": "2.0.0",
-				"@opentelemetry/core": "2.0.0",
-				"@opentelemetry/sdk-trace-base": "2.0.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
 			}
 		},
 		"node_modules/@opentelemetry/sdk-trace-base": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.0.tgz",
-			"integrity": "sha512-qQnYdX+ZCkonM7tA5iU4fSRsVxbFGml8jbxOgipRGMFHKaXKHQ30js03rTobYjKjIfnOsZSbHKWF0/0v0OQGfw==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.1.tgz",
+			"integrity": "sha512-xYLlvk/xdScGx1aEqvxLwf6sXQLXCjk3/1SQT9X9AoN5rXRhkdvIFShuNNmtTEPRBqcsMbS4p/gJLNI2wXaDuQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "2.0.0",
-				"@opentelemetry/resources": "2.0.0",
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.3.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-			"integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/resources": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
-			"integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.0.0",
+				"@opentelemetry/core": "2.0.1",
+				"@opentelemetry/resources": "2.0.1",
 				"@opentelemetry/semantic-conventions": "^1.29.0"
 			},
 			"engines": {
@@ -3031,27 +2384,10 @@
 				"@opentelemetry/api": ">=1.0.0 <1.10.0"
 			}
 		},
-		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/sdk-trace-base": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.1.tgz",
-			"integrity": "sha512-xYLlvk/xdScGx1aEqvxLwf6sXQLXCjk3/1SQT9X9AoN5rXRhkdvIFShuNNmtTEPRBqcsMbS4p/gJLNI2wXaDuQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.0.1",
-				"@opentelemetry/resources": "2.0.1",
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.3.0 <1.10.0"
-			}
-		},
 		"node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.33.0.tgz",
-			"integrity": "sha512-TIpZvE8fiEILFfTlfPnltpBaD3d9/+uQHVCyC3vfdh6WfCXKhNFzoP5RyDDIndfvZC5GrA4pyEDNyjPloJud+w==",
+			"version": "1.37.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.37.0.tgz",
+			"integrity": "sha512-JD6DerIKdJGmRp4jQyX5FlrQjA4tjOw1cvfsPAZXfOOEErMUHjPcPSICS+6WnM0nB0efSFARh0KAZss+bvExOA==",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=14"
@@ -3194,9 +2530,9 @@
 			}
 		},
 		"node_modules/@rocicorp/zero": {
-			"version": "0.22.2025080200",
-			"resolved": "https://registry.npmjs.org/@rocicorp/zero/-/zero-0.22.2025080200.tgz",
-			"integrity": "sha512-WM8QHcppkCT19rvICgFpgDqHDeIctZTmFlyuDPQy3l7UIeexdIJ+aBETrjpCXYcCYHotdwDyH5WUaWpwDjjfrQ==",
+			"version": "0.23.2025090100",
+			"resolved": "https://registry.npmjs.org/@rocicorp/zero/-/zero-0.23.2025090100.tgz",
+			"integrity": "sha512-a41pKENL/gN9K0DrfpFJWnF5NWIVuLNy13Yi+t6389JUpupAzk42Gw1YwZIxaUVkuBYylfjQxJOaCF3Yp/eTtA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@badrap/valita": "0.3.11",
@@ -3208,16 +2544,13 @@
 				"@fastify/websocket": "^11.0.0",
 				"@google-cloud/precise-date": "^4.0.0",
 				"@opentelemetry/api": "^1.9.0",
-				"@opentelemetry/api-logs": "^0.200.0",
-				"@opentelemetry/auto-instrumentations-node": "^0.58.1",
-				"@opentelemetry/exporter-logs-otlp-http": "^0.200.0",
-				"@opentelemetry/exporter-metrics-otlp-http": "^0.200.0",
-				"@opentelemetry/exporter-trace-otlp-http": "^0.200.0",
-				"@opentelemetry/resources": "^2.0.0",
-				"@opentelemetry/sdk-logs": "^0.200.0",
-				"@opentelemetry/sdk-metrics": "^2.0.0",
-				"@opentelemetry/sdk-node": "^0.200.0",
-				"@opentelemetry/sdk-trace-node": "^2.0.0",
+				"@opentelemetry/api-logs": "^0.203.0",
+				"@opentelemetry/auto-instrumentations-node": "^0.62.0",
+				"@opentelemetry/exporter-metrics-otlp-http": "^0.203.0",
+				"@opentelemetry/resources": "^2.0.1",
+				"@opentelemetry/sdk-metrics": "^2.0.1",
+				"@opentelemetry/sdk-node": "^0.203.0",
+				"@opentelemetry/sdk-trace-node": "^2.0.1",
 				"@postgresql-typed/oids": "^0.2.0",
 				"@rocicorp/lock": "^1.0.4",
 				"@rocicorp/logger": "^5.4.0",
@@ -3228,6 +2561,7 @@
 				"chalk": "^5.3.0",
 				"chalk-template": "^1.1.0",
 				"chokidar": "^4.0.1",
+				"cloudevents": "^10.0.0",
 				"command-line-args": "^6.0.1",
 				"command-line-usage": "^7.0.3",
 				"compare-utf8": "^0.1.1",
@@ -3717,9 +3051,9 @@
 			}
 		},
 		"node_modules/@types/aws-lambda": {
-			"version": "8.10.147",
-			"resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.147.tgz",
-			"integrity": "sha512-nD0Z9fNIZcxYX5Mai2CTmFD7wX7UldCkW2ezCF8D1T5hdiLsnTWDGRpfRYntU6VjTdLQjOvyszru7I1c1oCQew==",
+			"version": "8.10.152",
+			"resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.152.tgz",
+			"integrity": "sha512-soT/c2gYBnT5ygwiHPmd9a1bftj462NWVk2tKCc1PYHSIacB2UwbTS2zYG4jzag1mRDuzg/OjtxQjQ2NKRB6Rw==",
 			"license": "MIT"
 		},
 		"node_modules/@types/basic-auth": {
@@ -3800,9 +3134,9 @@
 			}
 		},
 		"node_modules/@types/mysql": {
-			"version": "2.15.26",
-			"resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.26.tgz",
-			"integrity": "sha512-DSLCOXhkvfS5WNNPbfn2KdICAmk8lLc+/PNvnPnF7gOdMZCxopXduqv0OQ13y/yA/zXTSikZZqVgybUxOEg6YQ==",
+			"version": "2.15.27",
+			"resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.27.tgz",
+			"integrity": "sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*"
@@ -3817,10 +3151,19 @@
 				"undici-types": "~6.21.0"
 			}
 		},
+		"node_modules/@types/oracledb": {
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/@types/oracledb/-/oracledb-6.5.2.tgz",
+			"integrity": "sha512-kK1eBS/Adeyis+3OlBDMeQQuasIDLUYXsi2T15ccNJ0iyUpQ4xDF7svFu3+bGVrI0CMBUclPciz+lsQR3JX3TQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
 		"node_modules/@types/pg": {
-			"version": "8.6.1",
-			"resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.1.tgz",
-			"integrity": "sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==",
+			"version": "8.15.5",
+			"resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.5.tgz",
+			"integrity": "sha512-LF7lF6zWEKxuT3/OR8wAZGzkg4ENGXFNyiV/JeOt9z5B+0ZVwbql9McqX5c/WStFq1GaGso7H1AzP/qSzmlCKQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*",
@@ -3836,12 +3179,6 @@
 			"dependencies": {
 				"@types/pg": "*"
 			}
-		},
-		"node_modules/@types/shimmer": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
-			"integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==",
-			"license": "MIT"
 		},
 		"node_modules/@types/tedious": {
 			"version": "4.0.14",
@@ -4139,9 +3476,9 @@
 			}
 		},
 		"node_modules/agent-base": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-			"integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 14"
@@ -4261,6 +3598,21 @@
 				"node": ">=8.0.0"
 			}
 		},
+		"node_modules/available-typed-arrays": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+			"integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+			"license": "MIT",
+			"dependencies": {
+				"possible-typed-array-names": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/avvio": {
 			"version": "9.1.0",
 			"resolved": "https://registry.npmjs.org/avvio/-/avvio-9.1.0.tgz",
@@ -4320,9 +3672,9 @@
 			}
 		},
 		"node_modules/bignumber.js": {
-			"version": "9.3.0",
-			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.0.tgz",
-			"integrity": "sha512-EM7aMFTXbptt/wZdMlBv2t8IViwQL+h6SLHosp8Yf0dqJMTnY6iL32opnAB6kAdL0SZPuvcAzFr31o0c/R3/RA==",
+			"version": "9.3.1",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+			"integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
 			"license": "MIT",
 			"engines": {
 				"node": "*"
@@ -4393,6 +3745,53 @@
 			"dependencies": {
 				"base64-js": "^1.3.1",
 				"ieee754": "^1.1.13"
+			}
+		},
+		"node_modules/call-bind": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+			"integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.0",
+				"es-define-property": "^1.0.0",
+				"get-intrinsic": "^1.2.4",
+				"set-function-length": "^1.2.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/call-bind-apply-helpers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/call-bound": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"get-intrinsic": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/callsites": {
@@ -4472,6 +3871,62 @@
 			"engines": {
 				"node": ">=12"
 			}
+		},
+		"node_modules/cloudevents": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/cloudevents/-/cloudevents-10.0.0.tgz",
+			"integrity": "sha512-uyzC+PpMMRawbouHO+3mlisr3QfEDObmo2pN4oTTF6dZncZgpIzdasZx0tRBFI1dMsqCLZZXMtz8cUuvYqHdbw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"ajv": "^8.11.0",
+				"ajv-formats": "^2.1.1",
+				"json-bigint": "^1.0.0",
+				"process": "^0.11.10",
+				"util": "^0.12.4",
+				"uuid": "^8.3.2"
+			},
+			"engines": {
+				"node": ">=20 <=24"
+			}
+		},
+		"node_modules/cloudevents/node_modules/ajv": {
+			"version": "8.17.1",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/cloudevents/node_modules/ajv-formats": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+			"integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+			"license": "MIT",
+			"dependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"ajv": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/cloudevents/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"license": "MIT"
 		},
 		"node_modules/clsx": {
 			"version": "2.1.1",
@@ -4715,6 +4170,23 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/define-data-property": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+			"license": "MIT",
+			"dependencies": {
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/defu": {
 			"version": "6.1.4",
 			"resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
@@ -4756,6 +4228,20 @@
 			},
 			"funding": {
 				"url": "https://dotenvx.com"
+			}
+		},
+		"node_modules/dunder-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/duplexify": {
@@ -4812,6 +4298,36 @@
 			},
 			"funding": {
 				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/es-define-property": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-errors": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-object-atoms": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+			"integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/esbuild": {
@@ -5449,6 +4965,21 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/for-each": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+			"integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+			"license": "MIT",
+			"dependencies": {
+				"is-callable": "^1.2.7"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/forwarded-parse": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
@@ -5500,6 +5031,19 @@
 				"node": ">=14"
 			}
 		},
+		"node_modules/gaxios/node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
 		"node_modules/gcp-metadata": {
 			"version": "6.1.1",
 			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
@@ -5521,6 +5065,43 @@
 			"license": "ISC",
 			"engines": {
 				"node": "6.* || 8.* || >= 10.*"
+			}
+		},
+		"node_modules/get-intrinsic": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.1.1",
+				"function-bind": "^1.1.2",
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"has-symbols": "^1.1.0",
+				"hasown": "^2.0.2",
+				"math-intrinsics": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+			"license": "MIT",
+			"dependencies": {
+				"dunder-proto": "^1.0.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/get-stream": {
@@ -5587,6 +5168,18 @@
 				"node": ">=14"
 			}
 		},
+		"node_modules/gopd": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/graphemer": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -5600,6 +5193,45 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/has-property-descriptors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+			"license": "MIT",
+			"dependencies": {
+				"es-define-property": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-symbols": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-tostringtag": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+			"license": "MIT",
+			"dependencies": {
+				"has-symbols": "^1.0.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/hasown": {
@@ -5683,9 +5315,9 @@
 			}
 		},
 		"node_modules/import-in-the-middle": {
-			"version": "1.13.2",
-			"resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.13.2.tgz",
-			"integrity": "sha512-Yjp9X7s2eHSXvZYQ0aye6UvwYPrVB5C2k47fuXjFKnYinAByaDZjh4t9MT2wEga9775n6WaIqyHnQhBxYtX2mg==",
+			"version": "1.14.2",
+			"resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.14.2.tgz",
+			"integrity": "sha512-5tCuY9BV8ujfOpwtAGgsTx9CGUapcFMEEyByLv1B+v2+6DhAcw+Zr0nhQT7uwaZ7DiourxFEscghOR8e1aPLQw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"acorn": "^8.14.0",
@@ -5725,6 +5357,34 @@
 				"node": ">= 10"
 			}
 		},
+		"node_modules/is-arguments": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+			"integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"has-tostringtag": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-callable": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/is-core-module": {
 			"version": "2.16.1",
 			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
@@ -5757,6 +5417,24 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/is-generator-function": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
+			"integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.3",
+				"get-proto": "^1.0.0",
+				"has-tostringtag": "^1.0.2",
+				"safe-regex-test": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-glob": {
@@ -5799,6 +5477,24 @@
 				"@types/estree": "^1.0.6"
 			}
 		},
+		"node_modules/is-regex": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+			"integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"gopd": "^1.2.0",
+				"has-tostringtag": "^1.0.2",
+				"hasown": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/is-stream": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -5809,6 +5505,21 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-typed-array": {
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+			"integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+			"license": "MIT",
+			"dependencies": {
+				"which-typed-array": "^1.1.16"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/isexe": {
@@ -6100,6 +5811,15 @@
 			},
 			"bin": {
 				"markdown-it": "bin/markdown-it.mjs"
+			}
+		},
+		"node_modules/math-intrinsics": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/mdurl": {
@@ -6507,9 +6227,9 @@
 			}
 		},
 		"node_modules/pg-protocol": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.0.tgz",
-			"integrity": "sha512-IpdytjudNuLv8nhlHs/UrVBhU0e78J0oIS/0AVdTbWxSOkFUVdsHC/NrorO6nXsQNDTT1kzDSOMJubBQviX18Q==",
+			"version": "1.10.3",
+			"resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
+			"integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
 			"license": "MIT"
 		},
 		"node_modules/pg-types": {
@@ -6583,6 +6303,15 @@
 			"resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
 			"integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
 			"license": "MIT"
+		},
+		"node_modules/possible-typed-array-names": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+			"integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
 		},
 		"node_modules/postcss": {
 			"version": "8.5.3",
@@ -6854,6 +6583,15 @@
 				"svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0"
 			}
 		},
+		"node_modules/process": {
+			"version": "0.11.10",
+			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+			"integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6.0"
+			}
+		},
 		"node_modules/process-warning": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
@@ -6871,9 +6609,9 @@
 			"license": "MIT"
 		},
 		"node_modules/protobufjs": {
-			"version": "7.5.2",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.2.tgz",
-			"integrity": "sha512-f2ls6rpO6G153Cy+o2XQ+Y0sARLOZ17+OGVLHrc3VUKcLHYKEKWbkSujdBWQXM7gKn5NTfp0XnRPZn1MIu8n9w==",
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+			"integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
 			"hasInstallScript": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -7209,6 +6947,23 @@
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 			"license": "MIT"
 		},
+		"node_modules/safe-regex-test": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+			"integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"is-regex": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/safe-regex2": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.0.0.tgz",
@@ -7271,6 +7026,23 @@
 			"integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
 			"license": "MIT"
 		},
+		"node_modules/set-function-length": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+			"integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+			"license": "MIT",
+			"dependencies": {
+				"define-data-property": "^1.1.4",
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.4",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/shallow-equal": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
@@ -7297,12 +7069,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/shimmer": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-			"integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
-			"license": "BSD-2-Clause"
 		},
 		"node_modules/signal-exit": {
 			"version": "3.0.7",
@@ -7899,6 +7665,19 @@
 				"node": ">=0.12.0"
 			}
 		},
+		"node_modules/util": {
+			"version": "0.12.5",
+			"resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+			"integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"is-arguments": "^1.0.4",
+				"is-generator-function": "^1.0.7",
+				"is-typed-array": "^1.1.3",
+				"which-typed-array": "^1.1.2"
+			}
+		},
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -7906,13 +7685,9 @@
 			"license": "MIT"
 		},
 		"node_modules/uuid": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
 			"license": "MIT",
 			"bin": {
 				"uuid": "dist/bin/uuid"
@@ -8041,6 +7816,27 @@
 			},
 			"engines": {
 				"node": "^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/which-typed-array": {
+			"version": "1.1.19",
+			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+			"integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+			"license": "MIT",
+			"dependencies": {
+				"available-typed-arrays": "^1.0.7",
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.4",
+				"for-each": "^0.3.5",
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"has-tostringtag": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/word-wrap": {
@@ -8182,6 +7978,16 @@
 			"integrity": "sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/zod": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.1.5.tgz",
+			"integrity": "sha512-rcUUZqlLJgBC33IT3PNMgsCq6TzLQEG/Ei/KTCU0PedSWRMAXoOUN+4t/0H+Q8bdnLPdqUYnvboJT0bn/229qg==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -47,12 +47,13 @@
 		"svelte-check": "^4.2.1",
 		"typescript": "^5.8.3",
 		"typescript-eslint": "^8.33.1",
-		"vite": "^6.3.3"
+		"vite": "^6.3.3",
+		"zod": "^4.1.5"
 	},
 	"svelte": "./dist/index.js",
 	"types": "./dist/index.d.ts",
 	"type": "module",
 	"dependencies": {
-		"@rocicorp/zero": "^0.22.2025080200"
+		"@rocicorp/zero": "^0.23.0"
 	}
 }

--- a/src/lib/Z.svelte.ts
+++ b/src/lib/Z.svelte.ts
@@ -1,15 +1,24 @@
 import { Zero, type Schema, type ZeroOptions, type CustomMutatorDefs } from '@rocicorp/zero';
+import { setContext } from 'svelte';
 
 // This is the state of the Zero instance
 // You can reset it on login or logout
-export class Z<
-	TSchema extends Schema,
-	MD extends CustomMutatorDefs<TSchema> | undefined = undefined
-> {
+export class Z<TSchema extends Schema, MD extends CustomMutatorDefs | undefined = undefined> {
 	current: Zero<TSchema, MD> = $state(null!);
 
 	constructor(z_options: ZeroOptions<TSchema, MD>) {
 		this.build(z_options);
+
+		try {
+			setContext('z', this);
+		} catch (error) {
+			console.error(
+				'Unable to use `setContext`. Please make sure to call `new Z()` in a component or set the context yourself in a component like this:\n\n' +
+					'import { setContext } from "svelte"\n' +
+					'import { Z } from "zero-svelte"\n\n' +
+					'const z = new Z<Schema>({})\nsetContext("z", z)'
+			);
+		}
 	}
 
 	build(z_options: ZeroOptions<TSchema, MD>) {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,7 +3,8 @@
 	import { PUBLIC_SERVER } from '$env/static/public';
 	import { Query } from '$lib/query.svelte.js';
 	import { Z } from '$lib/Z.svelte.js';
-	import { schema, type Schema } from '../schema.js';
+	import { queries, schema, type Schema } from '../schema.js';
+
 	const z = new Z<Schema>({
 		server: PUBLIC_SERVER,
 		schema,
@@ -20,9 +21,10 @@
 		}
 		return new Query(z.current.query.todo.related('type'));
 	});
-$inspect(todos.current)
+	$inspect(todos.current);
+
 	// Basic query
-	const types = new Query(z.current.query.type);
+	const types = new Query(queries.allTypes());
 
 	const randID = () => Math.random().toString(36).slice(2);
 

--- a/src/routes/api/get-queries/+server.ts
+++ b/src/routes/api/get-queries/+server.ts
@@ -1,0 +1,27 @@
+import { withValidation, type ReadonlyJSONValue } from '@rocicorp/zero';
+import { handleGetQueriesRequest } from '@rocicorp/zero/server';
+import { queries, schema } from '../../../schema.js';
+
+export async function POST({ request }) {
+	const q = await handleGetQueriesRequest(getQuery, schema, request);
+
+	return new Response(JSON.stringify(q));
+}
+
+// Build a map of queries with validation by name.
+const validated = Object.fromEntries(
+	Object.values(queries).map((q) => [q.queryName, withValidation(q)])
+);
+
+function getQuery(name: string, args: readonly ReadonlyJSONValue[]) {
+	const q = validated[name];
+	if (!q) {
+		throw new Error(`No such query: ${name}`);
+	}
+	return {
+		// First param is the context for contextful queries.
+		// `args` are validated using the `parser` you provided with
+		// the query definition.
+		query: q(undefined, ...args)
+	};
+}

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -5,12 +5,15 @@
 import {
 	ANYONE_CAN_DO_ANYTHING,
 	boolean,
+	createBuilder,
 	createSchema,
 	definePermissions,
 	relationships,
 	string,
+	syncedQuery,
 	table
 } from '@rocicorp/zero';
+import { z as zod } from 'zod';
 
 const types = table('type')
 	.columns({
@@ -54,3 +57,11 @@ export const permissions = definePermissions<AuthData, Schema>(schema, () => {
 		type: ANYONE_CAN_DO_ANYTHING
 	};
 });
+
+export const builder = createBuilder(schema);
+
+export const queries = {
+	allTypes: syncedQuery('allTypes', zod.tuple([]), () => {
+		return builder.type;
+	})
+};


### PR DESCRIPTION
The most important change in the lib is that `materialize` must be called from zero instead of from the query

```diff
- this.#view = this.query.materialize();
+ this.#view = this.z.current.materialize(this.query);
```

Zero React reference: https://github.com/rocicorp/mono/commit/2509c0316d12ca1e7caadd41fe7db3837deaebe1