### PR TITLE
ci: gate changesets to src/lib/** and package.json; add local verify …

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,4 +12,5 @@ If this PR should not trigger a release, apply the `skip-release` label.
 
 ## Testing
 
+- Run `npm run verify` locally before pushing
 - Steps to verify / screenshots

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Detect source changes (gates changeset)
+      - name: Detect publishable changes (gates changeset)
         uses: tj-actions/changed-files@v45
         id: changed
         with:
           files: |
-            src/**
+            src/lib/**
+            package.json
             !.changeset/**
 
       - name: Check for missing changeset

--- a/README.md
+++ b/README.md
@@ -106,3 +106,11 @@ See demo for real working code.
 See Zero docs for more info.
 
 Listen to [Syntax](Syntax.fm) for tasty web development treats.
+
+## Contributing
+
+- Run `npm ci` to install dependencies (Node 22+).
+- Run `npm run verify` before pushing. It formats, then fails if it produced diffs, and runs lint, typecheck, build, and package.
+- If a PR changes published code under `src/lib/**` or `package.json`, run `npm run changeset` and commit the generated `.changeset/*.md` file.
+- If a PR is docs/CI/dev-only and shouldn’t trigger a release, apply the `skip-release` label.
+- CI mirrors this flow and will gate PRs on missing changesets and uncommitted formatting.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "0.3.5",
 	"scripts": {
 		"dev": "vite dev",
-		"build": "vite build && npm run package",
+		"build": "vite build",
 		"dev:zero-cache": "zero-cache-dev -p src/schema.ts",
 		"preview": "vite preview",
 		"package": "svelte-kit sync && svelte-package && publint",
@@ -14,6 +14,8 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"lint": "eslint .",
 		"format": "prettier --write .",
+		"format:check": "prettier --check .",
+		"verify": "npm run format && (git diff --quiet || (echo \"Prettier made changes. Run 'npm run format' and commit them.\" && git --no-pager diff --name-only && exit 1)) && npm run lint && npm run check && npm run build && npm run package",
 		"dev:db-up": "docker compose --env-file .env -f ./docker/docker-compose.yml up",
 		"dev:db-down": "docker compose --env-file .env -f ./docker/docker-compose.yml down"
 	},

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import './styles.css';
-	// @ts-expect-error SvelteKit env import may not be recognized in some contexts
 	import { PUBLIC_SERVER } from '$env/static/public';
 	import { Query } from '$lib/query.svelte.js';
 	import { Z } from '$lib/Z.svelte.js';


### PR DESCRIPTION
…script and docs; remove stale ts-expect-error; add PR verify reminder

## Summary

- Describe the change and motivation

## Release impact

- [ ] This change affects published code
- [ ] This change is docs/CI/dev-only (no release)

If it affects published code, run `npm run changeset` and commit the generated `.changeset/*.md`.
If this PR should not trigger a release, apply the `skip-release` label.

## Testing

- Steps to verify / screenshots
