### PR TITLE
Add getter proxies to Z class for cleaner API

### DIFF
--- a/.changeset/1759281396-getter-proxies.md
+++ b/.changeset/1759281396-getter-proxies.md
@@ -1,0 +1,23 @@
+---
+'zero-svelte': minor
+---
+
+Add getter proxies to Z class for cleaner API
+
+Users can now access Zero instance methods directly via `z.query`, `z.mutate`, `z.clientID`, and `z.userID` instead of `z.current.query`, `z.current.mutate`, etc.
+
+The `.current` property remains available for backward compatibility.
+
+**Before:**
+```typescript
+const todos = new Query(z.current.query.todo);
+z.current.mutate.todo.insert({ id, title, completed: false });
+```
+
+**After:**
+```typescript
+const todos = new Query(z.query.todo);
+z.mutate.todo.insert({ id, title, completed: false });
+```
+
+This improves the developer experience while maintaining full reactivity when swapping Zero instances via `z.build()`.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ new Z<Schema>({
 	// userID: user_id, possibly from loader?
 	server: PUBLIC_SERVER,
 	schema
-	// auth: data.jwt,
+	// auth: data.jwt, if you need it
 });
 
 {@render children()}
@@ -66,7 +66,7 @@ export function get_z() {
 	// Instead of creating a typed context wrapper
 
 	// Basic: always enabled; materializes immediately
-	const todos = new Query(z.current.query.todo);
+	const todos = new Query(z.query.todo);
 
 	const randID = () => Math.random().toString(36).slice(2);
 
@@ -76,7 +76,7 @@ export function get_z() {
 		const newTodo = formData.get('newTodo') as string;
 		const id = randID();
 		if (newTodo) {
-			z.current.mutate.todo.insert({ id, title: newTodo, completed: false });
+			z.mutate.todo.insert({ id, title: newTodo, completed: false });
 			(event.target as HTMLFormElement).reset();
 		}
 	}
@@ -85,7 +85,7 @@ export function get_z() {
 		const checkbox = event.target as HTMLInputElement;
 		const id = checkbox.value;
 		const completed = checkbox.checked;
-		z.current.mutate.todo.update({ id, completed });
+		z.mutate.todo.update({ id, completed });
 	}
 </script>
 
@@ -122,7 +122,7 @@ export function get_z() {
 	// When false, the query won't materialize or register listeners,
 	// and `current` will be the default snapshot until re-enabled.
 	let todosEnabled = $state(true);
-	const todos = $derived.by(() => new Query(z.current.query.todo, todosEnabled));
+	const todos = $derived.by(() => new Query(z.query.todo, todosEnabled));
 
 	const randID = () => Math.random().toString(36).slice(2);
 	function onsubmit(event: Event) {
@@ -131,7 +131,7 @@ export function get_z() {
 		const newTodo = formData.get('newTodo') as string;
 		const id = randID();
 		if (newTodo) {
-			z.current.mutate.todo.insert({ id, title: newTodo, completed: false });
+			z.mutate.todo.insert({ id, title: newTodo, completed: false });
 			(event.target as HTMLFormElement).reset();
 		}
 	}
@@ -139,7 +139,7 @@ export function get_z() {
 		const checkbox = event.target as HTMLInputElement;
 		const id = checkbox.value;
 		const completed = checkbox.checked;
-		z.current.mutate.todo.update({ id, completed });
+		z.mutate.todo.update({ id, completed });
 	}
 </script>
 
@@ -181,15 +181,15 @@ Use a single `Query` instance and update it in response to user input. This avoi
 	let filtered_type: string | undefined = $state();
 
 	// Create once
-	const todos = new Query(z.current.query.todo.related('type'));
+	const todos = new Query(z.query.todo.related('type'));
 	const types = new Query(queries.allTypes());
 
 	function applyFilter(value: string) {
 		const ft = value || undefined;
 		filtered_type = ft;
 		const q = ft
-			? z.current.query.todo.where('type_id', '=', ft).related('type')
-			: z.current.query.todo.related('type');
+			? z.query.todo.where('type_id', '=', ft).related('type')
+			: z.query.todo.related('type');
 		todos.updateQuery(q);
 	}
 </script>
@@ -217,7 +217,7 @@ Use a single `Query` instance and update it in response to user input. This avoi
 Mutations & queries are done with just standard Zero.
 
 ```javascript
-z.current.mutate.todo.update({ id, completed });
+z.mutate.todo.update({ id, completed });
 ```
 
 See demo for real working code.

--- a/src/lib/Z.svelte.ts
+++ b/src/lib/Z.svelte.ts
@@ -1,10 +1,16 @@
-import { Zero, type Schema, type ZeroOptions, type CustomMutatorDefs } from '@rocicorp/zero';
+import {
+	Zero,
+	type Schema,
+	type ZeroOptions,
+	type CustomMutatorDefs,
+	type Query as QueryDef
+} from '@rocicorp/zero';
 import { setContext } from 'svelte';
 
 // This is the state of the Zero instance
 // You can reset it on login or logout
 export class Z<TSchema extends Schema, MD extends CustomMutatorDefs | undefined = undefined> {
-	current: Zero<TSchema, MD> = $state(null!);
+	#zero = $state<Zero<TSchema, MD>>(null!);
 
 	constructor(z_options: ZeroOptions<TSchema, MD>) {
 		this.build(z_options);
@@ -21,12 +27,40 @@ export class Z<TSchema extends Schema, MD extends CustomMutatorDefs | undefined 
 		}
 	}
 
+	// Reactive getters that proxy to internal Zero instance
+	get query() {
+		return this.#zero.query;
+	}
+
+	get mutate() {
+		return this.#zero.mutate;
+	}
+
+	get clientID() {
+		return this.#zero.clientID;
+	}
+
+	get userID() {
+		return this.#zero.userID;
+	}
+
+	materialize<TTable extends keyof TSchema['tables'] & string, TReturn>(
+		query: QueryDef<TSchema, TTable, TReturn>
+	) {
+		return this.#zero.materialize(query);
+	}
+
+	// Backward compatibility - keep .current working
+	get current() {
+		return this.#zero;
+	}
+
 	build(z_options: ZeroOptions<TSchema, MD>) {
 		// Create new Zero instance
-		this.current = new Zero(z_options);
+		this.#zero = new Zero(z_options);
 	}
 
 	close() {
-		this.current.close();
+		this.#zero.close();
 	}
 }

--- a/src/lib/query.svelte.ts
+++ b/src/lib/query.svelte.ts
@@ -80,7 +80,7 @@ class ViewWrapper<
 	#materializeIfNeeded() {
 		if (!this.enabled) return;
 		if (!this.#view) {
-			this.#view = this.z.current.materialize(this.query);
+			this.#view = this.z.materialize(this.query);
 			this.onMaterialized(this);
 		}
 	}
@@ -112,7 +112,7 @@ class ViewStore {
 			);
 		}
 
-		const hash = query.hash() + z?.current?.clientID;
+		const hash = query.hash() + z?.clientID;
 		let existing = this.#views.get(hash) as ViewWrapper<TSchema, TTable, TReturn> | undefined;
 
 		if (!existing) {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -13,13 +13,13 @@
 	});
 
 	// Stable Query instance; update when filter changes via event
-	const todos = new Query(z.current.query.todo.related('type'));
+	const todos = new Query(z.query.todo.related('type'));
 
 	function applyFilter(value: string) {
 		const ft = value || undefined;
 		const q = ft
-			? z.current.query.todo.where('type_id', '=', ft).related('type')
-			: z.current.query.todo.related('type');
+			? z.query.todo.where('type_id', '=', ft).related('type')
+			: z.query.todo.related('type');
 		todos.updateQuery(q);
 	}
 
@@ -35,7 +35,7 @@
 		const todo_type = formData.get('todo_type') as string;
 		const id = randID();
 		if (todo_name) {
-			z.current.mutate.todo.insert({ id, title: todo_name, completed: false, type_id: todo_type });
+			z.mutate.todo.insert({ id, title: todo_name, completed: false, type_id: todo_type });
 			(event.target as HTMLFormElement).reset();
 		}
 	}
@@ -44,7 +44,7 @@
 		const checkbox = event.target as HTMLInputElement;
 		const id = checkbox.value;
 		const completed = checkbox.checked;
-		z.current.mutate.todo.update({ id, completed });
+		z.mutate.todo.update({ id, completed });
 	}
 
 	function add_type(event: Event) {
@@ -53,7 +53,7 @@
 		const todo_type = formData.get('type') as string;
 		const id = randID();
 		if (todo_type) {
-			z.current.mutate.type.insert({ id, name: todo_type });
+			z.mutate.type.insert({ id, name: todo_type });
 			(event.target as HTMLFormElement).reset();
 		}
 	}

--- a/tests/harness/fakes.ts
+++ b/tests/harness/fakes.ts
@@ -56,16 +56,43 @@ export function makeZStub(opts?: { userID?: string }) {
 	const created: Array<{ query: unknown; tv: ReturnType<typeof makeTypedViewStub> }> = [];
 	let last: ReturnType<typeof makeTypedViewStub> | undefined;
 
+	const zeroInstance = {
+		userID: opts?.userID,
+		clientID: opts?.userID, // For stubs, clientID same as userID
+		query: {} as any, // Mock query builder
+		mutate: {} as any, // Mock mutate
+		materialize(query: unknown) {
+			const tv = makeTypedViewStub();
+			created.push({ query, tv });
+			last = tv;
+			return tv.view;
+		},
+		close() {}
+	};
+
 	const z = {
-		current: {
-			userID: opts?.userID,
-			materialize(query: unknown) {
-				const tv = makeTypedViewStub();
-				created.push({ query, tv });
-				last = tv;
-				return tv.view;
-			},
-			close() {}
+		// Getter proxies (mimicking the real Z class)
+		get query() {
+			return zeroInstance.query;
+		},
+		get mutate() {
+			return zeroInstance.mutate;
+		},
+		get clientID() {
+			return zeroInstance.clientID;
+		},
+		get userID() {
+			return zeroInstance.userID;
+		},
+		materialize(query: unknown) {
+			return zeroInstance.materialize(query);
+		},
+		close() {
+			return zeroInstance.close();
+		},
+		// Backward compatibility
+		get current() {
+			return zeroInstance;
 		}
 	};
 


### PR DESCRIPTION
Nice QOL api change that allows you to forgoe "current" by proxying mutate, query and others.

**Before:**
```typescript
const todos = new Query(z.current.query.todo);
z.current.mutate.todo.insert({ id, title, completed: false });
```

**After:**
```typescript
const todos = new Query(z.query.todo);
z.mutate.todo.insert({ id, title, completed: false });
```

z.current still works for now to prevent breaking anything.