### PR TITLE
Add preload and 

### DIFF
--- a/.changeset/dry-phones-worry.md
+++ b/.changeset/dry-phones-worry.md
@@ -1,0 +1,5 @@
+---
+'zero-svelte': patch
+---
+
+Add preload and run proxies for synced-queries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,12 +57,14 @@
 ### Minor Changes
 
 - [#42](https://github.com/stolinski/zero-svelte/pull/42) [`99249a4`](https://github.com/stolinski/zero-svelte/commit/99249a4288db616e2c108015346aa38c18760e60) Thanks [@stolinski](https://github.com/stolinski)! - Add optional `enabled` flag to `Query` API to gate materialization.
+
   - `new Query(query, enabled = true)` and `query.updateQuery(query, enabled = true)` now accept an `enabled` boolean.
   - When `enabled` is `false`, the query does not materialize or register listeners; `current` exposes the default snapshot (`undefined` for singular, `[]` for plural) with details `{ type: 'unknown' }` until re-enabled.
   - When re-enabled (`true`), materialization begins and snapshots update as data arrives.
   - Default remains `true`, so existing code continues to work unchanged.
 
   Notes
+
   - View sharing behavior is unchanged: materializations are still keyed by `query.hash()` plus `userID`.
   - This is a backwards-compatible enhancement intended for conditional loading (e.g., route guards, feature toggles).
 

--- a/src/lib/Z.svelte.ts
+++ b/src/lib/Z.svelte.ts
@@ -56,13 +56,15 @@ export class Z<TSchema extends Schema, MD extends CustomMutatorDefs | undefined 
 
 	preload<TTable extends keyof TSchema['tables'] & string>(
 		query: QueryDef<TSchema, TTable, any>,
-		options?: {
-		/**
-		 * Time To Live. This is the amount of time to keep the rows associated with
-		 * this query after {@linkcode cleanup} has been called.
-		 */
-			ttl?: TTL | undefined;
-		} | undefined
+		options?:
+			| {
+					/**
+					 * Time To Live. This is the amount of time to keep the rows associated with
+					 * this query after {@linkcode cleanup} has been called.
+					 */
+					ttl?: TTL | undefined;
+			  }
+			| undefined
 	): { cleanup: () => void; complete: Promise<void> } {
 		return this.#zero.preload(query, options);
 	}

--- a/src/lib/Z.svelte.ts
+++ b/src/lib/Z.svelte.ts
@@ -1,11 +1,13 @@
 import {
+	RunOptions,
+	TTL,
 	Zero,
-	type Schema,
-	type ZeroOptions,
 	type CustomMutatorDefs,
+	type HumanReadable,
 	type Query as QueryDef,
+	type Schema,
 	type TypedView,
-	type HumanReadable
+	type ZeroOptions
 } from '@rocicorp/zero';
 import { setContext } from 'svelte';
 
@@ -50,6 +52,23 @@ export class Z<TSchema extends Schema, MD extends CustomMutatorDefs | undefined 
 
 	get online(): boolean {
 		return this.#online;
+	}
+
+	preload<TTable extends keyof TSchema['tables'] & string>(
+		query: QueryDef<TSchema, TTable, any>,
+		options?: {
+		/**
+		 * Time To Live. This is the amount of time to keep the rows associated with
+		 * this query after {@linkcode cleanup} has been called.
+		 */
+			ttl?: TTL | undefined;
+		} | undefined
+	): { cleanup: () => void; complete: Promise<void> } {
+		return this.#zero.preload(query, options);
+	}
+
+	run<Q>(query: Q, runOptions?: RunOptions | undefined) {
+		return this.#zero.run(query, runOptions);
 	}
 
 	materialize<TTable extends keyof TSchema['tables'] & string, TReturn>(


### PR DESCRIPTION
## Summary

This adds proxies for `preload` and `run` which are used in syncedQueries.

## Release impact

- [x] This change affects published code