### PR TITLE
fix: preserve auth context in Query.updateQuery()

### DIFF
--- a/src/lib/query.svelte.ts
+++ b/src/lib/query.svelte.ts
@@ -79,9 +79,12 @@ export class Query<
 		newQuery: QueryOrQueryRequest<any, any, any, TSchema, TReturn, any>,
 		enabled: boolean = true
 	) {
-		this.#query_impl = addContextToQuery(newQuery, {}) as QueryDef<TTable, TSchema, TReturn>;
+		this.#query_impl = addContextToQuery(newQuery, this.#z.context) as QueryDef<
+			TTable,
+			TSchema,
+			TReturn
+		>;
 		this.#view = this.#z.viewStore.getView(this.#z, this.#query_impl, enabled);
-		// Setting #view (a $state) will trigger reactivity in components reading .data/.details
 	}
 
 	// Cleanup method to destroy the persistent effect


### PR DESCRIPTION
**_*WARNING* I'm not an expert in Zero or Typescript. I had a bug and this resolved it for me..._**

`updateQuery()` was passing `{}` instead of `this.#z.context`:

```typescript
// Before (broken):
this.#query_impl = addContextToQuery(newQuery, {});

// After (matches createQuery):
this.#query_impl = addContextToQuery(newQuery, this.#z.context);
```

Without the auth context, permission rules using `authData.sub` receive undefined, causing row-level security to silently deny access.
